### PR TITLE
Updating to new project.json schema

### DIFF
--- a/src/pages/events/[page_id].astro
+++ b/src/pages/events/[page_id].astro
@@ -1,115 +1,106 @@
 ---
-import type { GetStaticPaths } from "astro";
-import projectData from '@data/project.json';
-import { dynamicConfig } from "dynamic-astro-config";
-import Layout from "@layouts/Layout.astro";
-import Container from "@components/Container.astro";
-import Player from "@components/Player";
+import type { GetStaticPaths } from 'astro';
+import { dynamicConfig } from 'dynamic-astro-config';
+import Layout from '@layouts/Layout.astro';
+import Container from '@components/Container.astro';
+import Player from '@components/Player';
+import pageOrder from '@data/pages/order.json';
 
 const baseUrl = dynamicConfig.base;
 
 export const getStaticPaths = (() => {
-    const eventPages = Object.keys(projectData.pages).filter((page) => (projectData.pages[page as keyof typeof projectData.pages].autogenerate.enabled && projectData.pages[page as keyof typeof projectData.pages].autogenerate.type == 'event'));
-    return eventPages.map((page) => ( 
-        {
-            params: { page_id: page }
-        }
-    ));
+  return pageOrder.map((page) => ({
+    params: { page_id: page },
+  }));
 }) satisfies GetStaticPaths;
 
 const { page_id } = Astro.params;
 
 if (!page_id) {
-    return Astro.redirect('/');
+  return Astro.redirect('/');
 }
 
 const pages = import.meta.glob('@data/pages/*.json');
 const eventImport = import.meta.glob('@data/events/*.json');
-const thisPageKey = Object.keys(pages).find((page) => (page.includes(page_id)));
+const thisPageKey = Object.keys(pages).find((page) => page.includes(page_id));
 if (!thisPageKey) {
-    return Astro.redirect('/')
+  return Astro.redirect('/');
 }
 const thisPage: any = await pages[thisPageKey]();
 
 const events = thisPage.default.autogenerate.type_id;
 
 if (!events) {
-    console.log('No events listed')
-    return Astro.redirect('/')
+  console.log('No events listed');
+  return Astro.redirect('/');
 }
 
 //right now I'm setting this up to handle either a string of a single event or an array of event IDs
-const thisEventKeys = typeof events == 'string' ? [Object.keys(eventImport).find((event) => (event.includes(events)))] : Object.keys(eventImport).filter((event) => events.findIndex((e: string) => event.includes(e)) > -1);
+const thisEventKeys =
+  typeof events == 'string'
+    ? [Object.keys(eventImport).find((event) => event.includes(events))]
+    : Object.keys(eventImport).filter(
+        (event) => events.findIndex((e: string) => event.includes(e)) > -1
+      );
 console.log(thisEventKeys, events, eventImport);
 
 if (!thisEventKeys || !thisEventKeys.length) {
-    return Astro.redirect(`/${baseUrl}`);
+  return Astro.redirect(`/${baseUrl}`);
 }
 //get event info
 let allEvents: any = {};
 
-for (let i=0; i < thisEventKeys.length; i++) {
-    const current = thisEventKeys[i];
-    if (current) {
-        const currentDetail: any = await eventImport[current]();
-        allEvents[current] = currentDetail?.default;
-    }
+for (let i = 0; i < thisEventKeys.length; i++) {
+  const current = thisEventKeys[i];
+  if (current) {
+    const currentDetail: any = await eventImport[current]();
+    allEvents[current] = currentDetail?.default;
+  }
 }
- console.log(allEvents);
+console.log(allEvents);
 
 //get annotation info
 
 const annotationsResponse = await Astro.glob('@data/annotations/*.json');
 
-const pageAnnotations = annotationsResponse.filter((ann) => (events.includes(ann.default.event_id))).map((ann) => (ann.default));
-
-
-
+const pageAnnotations = annotationsResponse
+  .filter((ann) => events.includes(ann.default.event_id))
+  .map((ann) => ann.default);
 ---
 
 <Layout title={thisPage.default.title}>
-    <Container className="py-16">
-        {
-            Object.values(allEvents).map((event: any) => {
-                console.log(event.audiovisual_files)
-                return ( 
-                    <div>
-                        <h1>
-                            { event.label }
-                        </h1>
-                        {
-                            Object.keys(event.audiovisual_files).map((file: string) => {
-                                const url: string = event.audiovisual_files[file].file_url;
-                                return ( 
-                                    <div class="flex flex-col gap-4">
-                                        <Player url={url} client:only="react" />
-                                        <div class="border border-collapse border-black">
-                                            {
-                                                pageAnnotations.find((ann) => (ann.source_id == file))?.annotations.map((ann: any) => ( 
-                                                    <div class="flex flex-row justify-between p-4 border-t border-b border-t-black border-b-black">
-                                                        <p>
-                                                            {`${ann.start_time}-${ann.end_time}`}
-                                                        </p>
-                                                        <div class="flex flex-col gap-2">
-                                                            {
-                                                                ann.tags?.map((tag: any) => ( 
-                                                                    <p>
-                                                                        {`${tag.category}: ${tag.tag}`}
-                                                                    </p>
-                                                                ))
-                                                            }
-                                                        </div>
-                                                    </div>
-                                                ))
-                                            }
-                                        </div>
-                                    </div>
-                                )
-                            })
-                        }
-                    </div>
-                )
-            })
-        }
-    </Container>
+  <Container className='py-16'>
+    {
+      Object.values(allEvents).map((event: any) => {
+        console.log(event.audiovisual_files);
+        return (
+          <div>
+            <h1>{event.label}</h1>
+            {Object.keys(event.audiovisual_files).map((file: string) => {
+              const url: string = event.audiovisual_files[file].file_url;
+              return (
+                <div class='flex flex-col gap-4'>
+                  <Player url={url} client:only='react' />
+                  <div class='border border-collapse border-black'>
+                    {pageAnnotations
+                      .find((ann) => ann.source_id == file)
+                      ?.annotations.map((ann: any) => (
+                        <div class='flex flex-row justify-between p-4 border-t border-b border-t-black border-b-black'>
+                          <p>{`${ann.start_time}-${ann.end_time}`}</p>
+                          <div class='flex flex-col gap-2'>
+                            {ann.tags?.map((tag: any) => (
+                              <p>{`${tag.category}: ${tag.tag}`}</p>
+                            ))}
+                          </div>
+                        </div>
+                      ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        );
+      })
+    }
+  </Container>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,27 +1,53 @@
 ---
-import Layout from "../layouts/Layout.astro";
+import Layout from '../layouts/Layout.astro';
 // import projectData from "@data/project.json";
-import projectData from "@data/project.json";
-import Container from "../components/Container.astro";
-import { dynamicConfig } from "dynamic-astro-config";
+import projectData from '@data/project.json';
+import Container from '../components/Container.astro';
+import { dynamicConfig } from 'dynamic-astro-config';
+import pageOrder from '@data/pages/order.json';
+
 const project = projectData.project;
 
 const baseUrl = dynamicConfig.base;
 
+//need to get pages from the /pages folder
+const pageResponse = import.meta.glob('@data/pages/*.json');
+
+let pageData: any = {};
+
+for (let i = 0; i < pageOrder.length; i++) {
+  const thisPage = Object.keys(pageResponse).find((key) =>
+    key.includes(pageOrder[i])
+  );
+  if (thisPage) {
+    const thisPageData: any = await pageResponse[thisPage]();
+    pageData[pageOrder[i]] = thisPageData.default;
+  }
+}
 ---
 
-<Layout title={project.title} projectName={project.title} projectBy={project.creator}>
-  <Container className="py-12 flex flex-col gap-6">
+<Layout
+  title={project.title}
+  projectName={project.title}
+  projectBy={project.creator}
+>
+  <Container className='py-12 flex flex-col gap-6'>
     <h1>{project.title}</h1>
     <h2>{project.description}</h2>
-    <div class="py-12 flex flex-col gap-2">
+    <div class='py-12 flex flex-col gap-2'>
       <a href={`/${baseUrl}/tags`}>Index</a>
       {
-        Object.keys(projectData.pages).filter((page) => (projectData.pages[page as keyof typeof projectData.pages].autogenerate.type == 'event')).sort((a,b) => (projectData.pageOrder.indexOf(a) - projectData.pageOrder.indexOf(b))).map((page) => ( 
-          <a href={`/${baseUrl}/events/${page}`}>
-            { projectData.pages[page as keyof typeof projectData.pages].title }
-          </a>
-        ))
+        Object.keys(pageData)
+          .filter(
+            (page) =>
+              pageData[page as keyof typeof pageData].autogenerate.type ==
+              'event'
+          )
+          .map((page) => (
+            <a href={`/${baseUrl}/events/${page}`}>
+              {pageData[page as keyof typeof pageData].title}
+            </a>
+          ))
       }
     </div>
   </Container>


### PR DESCRIPTION
### In this PR
Updates the autogenerated home and event pages to not rely on page data being included directly in the `project.json` file in the data repo.

(Note: Many of the changes logged below are cosmetic, as I am now using Prettier to format automatically on save and I wasn't when these files were first committed -- my bad!)