### PR TITLE
Better error handling if no annotation/event files

### DIFF
--- a/src/pages/events/[page_id].astro
+++ b/src/pages/events/[page_id].astro
@@ -61,12 +61,16 @@ for (let i = 0; i < thisEventKeys.length; i++) {
 }
 
 //get annotation info
+let pageAnnotations: any[] = [];
+//check whether there actually are any annotation files
+const annotationFiles = import.meta.glob('@data/annotations/*.json');
+if (Object.keys(annotationFiles).length) {
+  const annotationsResponse = await Astro.glob('@data/annotations/*.json');
 
-const annotationsResponse = await Astro.glob('@data/annotations/*.json');
-
-const pageAnnotations = annotationsResponse
-  .filter((ann) => events.includes(ann.default.event_id))
-  .map((ann) => ann.default);
+  pageAnnotations = annotationsResponse
+    .filter((ann) => events.includes(ann.default.event_id))
+    .map((ann) => ann.default);
+}
 ---
 
 <Layout title={thisPage.default.title}>
@@ -81,20 +85,22 @@ const pageAnnotations = annotationsResponse
               return (
                 <div class='flex flex-col gap-4'>
                   <Player url={url} client:only='react' />
-                  <div class='border border-collapse border-black'>
-                    {pageAnnotations
-                      .find((ann) => ann.source_id == file)
-                      ?.annotations.map((ann: any) => (
-                        <div class='flex flex-row justify-between p-4 border-t border-b border-t-black border-b-black'>
-                          <p>{`${ann.start_time}-${ann.end_time}`}</p>
-                          <div class='flex flex-col gap-2'>
-                            {ann.tags?.map((tag: any) => (
-                              <p>{`${tag.category}: ${tag.tag}`}</p>
-                            ))}
+                  {pageAnnotations.length ? (
+                    <div class='border border-collapse border-black'>
+                      {pageAnnotations
+                        .find((ann: any) => ann.source_id == file)
+                        ?.annotations.map((ann: any) => (
+                          <div class='flex flex-row justify-between p-4 border-t border-b border-t-black border-b-black'>
+                            <p>{`${ann.start_time}-${ann.end_time}`}</p>
+                            <div class='flex flex-col gap-2'>
+                              {ann.tags?.map((tag: any) => (
+                                <p>{`${tag.category}: ${tag.tag}`}</p>
+                              ))}
+                            </div>
                           </div>
-                        </div>
-                      ))}
-                  </div>
+                        ))}
+                    </div>
+                  ) : null}
                 </div>
               );
             })}

--- a/src/pages/tags/detail.astro
+++ b/src/pages/tags/detail.astro
@@ -23,6 +23,12 @@ const crumbs = [
 ];
 
 const tags = projectData.project.tags;
+
+//check whether there actually are any annotation files
+const annotationFiles = import.meta.glob('@data/annotations/*.json');
+if (!Object.keys(annotationFiles).length) {
+  return Astro.redirect(`/${baseUrl}`);
+}
 const annotations = await Astro.glob('@data/annotations/*.json');
 const events = import.meta.glob('@data/events/*.json');
 let eventsWithAnnotations = annotations.map((page) => page.default);

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -19,6 +19,13 @@ const crumbs = [
 ];
 
 const tags = projectData.project.tags;
+
+//check whether there actually are any annotation files
+const annotationFiles = import.meta.glob('@data/annotations/*.json');
+if (!Object.keys(annotationFiles).length) {
+  return Astro.redirect(`/${baseUrl}`);
+}
+
 const annotations = await Astro.glob('@data/annotations/*.json');
 const detectTag = (
   tag: { tag: string; category: string },


### PR DESCRIPTION
### In this PR
Cleans up (hopefully) some errors that arise in the case that there are no annotation files present in the data, since `Astro.glob` throws an error when it finds no matches. ([Controversial but apparently intentional](https://github.com/withastro/astro/issues/5091) behavior on Astro's part.)