### PR TITLE
Made player on auto event pages sticky

### DIFF
--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -25,6 +25,7 @@ interface Props {
   playing?: boolean;
   position?: number;
   id: string;
+  sticky?: boolean;
 }
 
 const ReactPlayer = _ReactPlayer as unknown as React.FC<ReactPlayerProps>;
@@ -97,7 +98,7 @@ const Player: React.FC<Props> = (props) => {
   }, []);
 
   return (
-    <div>
+    <div className={`${props.sticky ? 'sticky top-2' : ''}`}>
       {/* the player doesn't have any UI when playing audio files, so let's keep it 0x0 */}
       {/* when we add video support, we'll need to conditionally set the width/height */}
       <ReactPlayer

--- a/src/components/PlayerWithAnnotations.astro
+++ b/src/components/PlayerWithAnnotations.astro
@@ -6,17 +6,18 @@ export interface Props {
   file: string;
   url: string;
   annotations?: any[];
+  sticky?: boolean;
 }
 
-const { file, url, annotations } = Astro.props;
+const { file, url, annotations, sticky = false } = Astro.props;
 ---
 
 <div
-  class='mediaContainer flex flex-col gap-4'
+  class={`mediaContainer flex flex-col gap-4${sticky ? ' sticky top-0' : ''}`}
   data-player-id={file}
   data-player-url={url}
 >
-  <Player url={url} id={file} client:only='react' />
+  <Player url={url} id={file} client:only='react' sticky={sticky} />
   {
     annotations ? (
       <Annotations playerId={file} annotations={annotations} />

--- a/src/pages/events/[pageUuid].astro
+++ b/src/pages/events/[pageUuid].astro
@@ -72,6 +72,7 @@ const annotations = annotationData.filter((ad) =>
                   file={file}
                   annotations={annotationsToShow}
                   url={url}
+                  sticky
                 />
               );
             })}


### PR DESCRIPTION
### In this PR
Adds a `sticky` prop to the `PlayerWithAnnotations` component that sets that positioning of the player so that it sticks to the top of the page when scrolled. Addresses https://github.com/AVAnnotate/admin-client/issues/80.