### PR TITLE
Debugging tag filters

### DIFF
--- a/src/components/AnnotationUI/Annotations.astro
+++ b/src/components/AnnotationUI/Annotations.astro
@@ -28,16 +28,16 @@ if (annotations && annotations.length) {
   annotations.forEach((ann) => {
     if (ann.tags && ann.tags.length) {
       ann.tags.forEach((tag: { category: string; tag: string }) => {
-        allTags[tag.category] ||= {
+        const cat = tag.category.toLowerCase();
+        allTags[cat] ||= {
           tags: [],
           color:
-            tagGroups.find(
-              (grp) => grp.category.toLowerCase() == tag.category.toLowerCase()
-            )?.color || '#FFF',
+            tagGroups.find((grp) => grp.category.toLowerCase() == cat)?.color ||
+            '#FFF',
         };
-        if (!allTags[tag.category].tags.includes(tag.tag)) {
-          allTags[tag.category].tags.push(tag.tag);
-          allTags[tag.category].tags.sort();
+        if (!allTags[cat].tags.includes(tag.tag)) {
+          allTags[cat].tags.push(tag.tag);
+          allTags[cat].tags.sort();
         }
       });
     }

--- a/src/components/AnnotationUI/TagFilter.tsx
+++ b/src/components/AnnotationUI/TagFilter.tsx
@@ -58,7 +58,9 @@ const TagFilter = (props: TagFilterProps) => {
         category: category,
         tag: tag,
       }));
-      const active = thisPlayer.activeFilters || [];
+      const active = thisPlayer.activeFilters
+        ? [...thisPlayer.activeFilters]
+        : [];
       allCategoryTags.forEach((tag) => {
         if (
           active.findIndex(
@@ -113,7 +115,7 @@ const TagFilter = (props: TagFilterProps) => {
           categories.map((cat, idx) => (
             <>
               {idx > 0 ? (
-                <div className='h-[2px] bg-gray-500 rounded-full w-full py-2' />
+                <div className='h-[1px] bg-gray-500 rounded-full w-full my-3' />
               ) : null}
               <div className='flex flex-col gap-2' key={idx}>
                 <div className='flex flex-row gap-3 py-1'>


### PR DESCRIPTION
### In this PR
- Addresses Issue #16 where the category filter checkbox wasn't working correctly.
- Tag filter will now group tags together if they have the same (case insensitive) category name, rather than separating e.g. `speaker` and `Speaker`.