### PR TITLE
Make event description optional in schema

### DIFF
--- a/src/components/Event.astro
+++ b/src/components/Event.astro
@@ -41,7 +41,7 @@ const annotations = annotationData.filter((ad) =>
       <div class='flex flex-col gap-6 bg-gray-100'>
         {includes.includes('label') && <h1>{event.data.label}</h1>}
         {includes.includes('description') && (
-          <RichText nodes={event.data.description} />
+          <RichText nodes={event.data.description || []} />
         )}
         {(includes.includes('annotations') || includes.includes('media')) &&
           Object.keys(event.data.audiovisual_files).map((file: string) => {

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -20,7 +20,7 @@ const eventCollection = defineCollection({
       })
     ),
     auto_generate_web_page: z.boolean(),
-    description: slateNodeArray,
+    description: slateNodeArray.nullish(),
     citation: z.string().nullish(),
     created_at: z.string(),
     created_by: z.string(),


### PR DESCRIPTION
This PR fixes an issue where the `description` field was incorrectly marked as required in the event schema, causing build failures for projects containing events that didn't have descriptions.