### PR TITLE
Fix link display in rich text component

### DIFF
--- a/src/components/RichText/Leaves/Link.astro
+++ b/src/components/RichText/Leaves/Link.astro
@@ -3,8 +3,13 @@ const { leaf } = Astro.props;
 ---
 
 {
-  leaf.italic ? (
-    <a href={leaf.link} target='_blank' rel='noopener noreferrer'>
+  leaf.link ? (
+    <a
+      href={leaf.link}
+      target='_blank'
+      rel='noopener noreferrer'
+      class='text-blue-500 underline'
+    >
       <slot />
     </a>
   ) : (


### PR DESCRIPTION
# Summary

Links weren't showing up because the `Link` component was checking whether the element was italicized instead of whether it's a link. Oops! This PR fixes that and adds styling to make the links blue and underlined (it seems like Tailwind overrides the default browser styles for links).