### PR TITLE
Show user-provided name as project creator if it exists

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -12,15 +12,16 @@ interface Props {
   background?: string;
   title?: string;
   projectName?: string;
-  projectBy?: string;
 }
 
 const {
   background,
   title = projectData.data.project.title,
   projectName = projectData.data.project.title,
-  projectBy = projectData.data.project.creator,
 } = Astro.props;
+
+const projectBy =
+  projectData.data.project.authors || projectData.data.project.creator;
 ---
 
 <!doctype html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,11 +32,7 @@ pages.sort((a, b) => {
 });
 ---
 
-<Layout
-  title={project.title}
-  projectName={project.title}
-  projectBy={project.creator}
->
+<Layout title={project.title} projectName={project.title}>
   <Container className='py-12 flex flex-col gap-6'>
     <h1>{project.title}</h1>
     <h2>{project.description}</h2>


### PR DESCRIPTION
# Summary

This PR updates the logic in the `Layout` component to prioritize showing the `users` project field (which optionally contains a string entered by the user) in place of the creator's GitHub name if it exists.