### PR TITLE
Update filter menu and add set filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro check && astro build",
+    "build": "rm -rf ./dist && astro check && astro build",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/src/components/Container.astro
+++ b/src/components/Container.astro
@@ -5,7 +5,10 @@ const { className } = Astro.props;
 ---
 
 <div
-  class={clsx('mx-6 md:mx-24 xl:mx-32 2xl:mx-auto max-w-screen-2xl', className)}
+  class={clsx(
+    'mx-6 md:mx-24 xl:mx-32 2xl:mx-auto 2xl:w-full max-w-screen-2xl',
+    className
+  )}
 >
   <slot />
 </div>

--- a/src/components/EventViewer/AnnotationUI/Annotations/Annotation.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/Annotation.astro
@@ -4,6 +4,12 @@ import { PlayCircleIcon } from '@heroicons/react/24/outline';
 import TagPill from '@components/tags/TagPill';
 import { formatTimestamp } from 'src/utils/player';
 import { getEntry } from 'astro:content';
+import type { Annotation } from '@ty/index';
+
+interface Props {
+  ann: Annotation & { set: string };
+  playerId: string;
+}
 
 const { ann, playerId } = Astro.props;
 
@@ -16,6 +22,7 @@ const tagGroups = projectData.data.project.tags.tagGroups;
   data-start={ann.start_time}
   data-end={ann.end_time}
   data-tags={JSON.stringify(ann.tags)}
+  data-set={ann.set}
 >
   <div class='flex flex-row gap-2 w-[140px] items-start'>
     <button

--- a/src/components/EventViewer/AnnotationUI/Annotations/Annotation.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/Annotation.astro
@@ -9,9 +9,10 @@ import type { Annotation } from '@ty/index';
 interface Props {
   ann: Annotation & { set: string };
   playerId: string;
+  setName?: string;
 }
 
-const { ann, playerId } = Astro.props;
+const { ann, playerId, setName } = Astro.props;
 
 const projectData = await getEntry('project', 'project');
 const tagGroups = projectData.data.project.tags.tagGroups;
@@ -39,7 +40,16 @@ const tagGroups = projectData.data.project.tags.tagGroups;
       }
     </p>
   </div>
-  <div class='w-full flex flex-col gap-4'>
+  <div class='w-full flex flex-col gap-4 text-sm'>
+    {
+      setName && (
+        <div>
+          <span class='text-xs font-semibold bg-gray-200 py-1 px-2 rounded-md'>
+            {setName}
+          </span>
+        </div>
+      )
+    }
     <RichText nodes={ann.annotation} />
     <div class='flex flex-row gap-4 annotationTags' data-player-id={playerId}>
       {

--- a/src/components/EventViewer/AnnotationUI/Annotations/AnnotationHeader.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/AnnotationHeader.astro
@@ -7,37 +7,14 @@ import { getEntry } from "astro:content";
 import type { CollectionEntry } from "astro:content";
 
 interface Props {
-  annotationSet: CollectionEntry<'annotations'>,
+  annotationSets: CollectionEntry<'annotations'>[],
   playerId: string,
   type: 'Audio' | 'Video'
 }
 
 const projectData = await getEntry('project', 'project');
 
-const { annotationSet, playerId, type } = Astro.props;
-
-const tagGroups = projectData.data.project.tags.tagGroups;
-
-let allTags: { [key: string]: { tags: string[]; color: string } } = {};
-if (annotationSet.data.annotations.length > 0) {
-  annotationSet.data.annotations.forEach((ann) => {
-    if (ann.tags && ann.tags.length) {
-      ann.tags.forEach((tag: { category: string; tag: string }) => {
-        const cat = tag.category.toLowerCase();
-        allTags[cat] ||= {
-          tags: [],
-          color:
-            tagGroups.find((grp) => grp.category.toLowerCase() === cat)?.color ||
-            '#FFF',
-        };
-        if (!allTags[cat].tags.includes(tag.tag)) {
-          allTags[cat].tags.push(tag.tag);
-          allTags[cat].tags.sort();
-        }
-      });
-    }
-  });
-}
+const { annotationSets, playerId, type } = Astro.props;
 
 ---
 <div>
@@ -65,7 +42,7 @@ if (annotationSet.data.annotations.length > 0) {
       )
     }
       <TextSearch playerId={playerId} client:only='react' />
-      <TagFilter playerId={playerId} tags={allTags} client:only='react' />
+      <TagFilter annotationSets={annotationSets} playerId={playerId} projectData={projectData} client:only='react' />
     </div>
   </div>
 </div>

--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -34,6 +34,7 @@ const sortedAnnotations = annotationSets
 </div>
 
 <script>
+  import type { Tag } from '@ty/index.ts';
   import { $pagePlayersState } from 'src/store.ts';
   const annotationPlayNodes = document.getElementsByClassName('playAnnotation');
   const annotationNodes = document.getElementsByClassName('annotationNode');
@@ -120,77 +121,75 @@ const sortedAnnotations = annotationSets
         }
       }
     }
+
     //filter on sets, text, and tags
-    if (
-      changed &&
-      (state[changed].searchQuery != oldState[changed].searchQuery ||
-        state[changed].activeFilters != oldState[changed].activeFilters ||
-        state[changed].sets.length != oldState[changed].sets.length)
-    ) {
+    if (changed) {
       for (let i = 0; i < annotationNodes.length; i++) {
         const thisNode = annotationNodes[i];
 
-        const setFiltersEmpty = state[changed].sets.length === 0;
-        const set = thisNode.getAttribute('data-set');
+        // hide if its set is hidden
+        if (state[changed].sets.length > 0) {
+          const setFiltersEmpty = state[changed].sets.length === 0;
+          const set = thisNode.getAttribute('data-set');
 
-        if (set) {
-          if (!setFiltersEmpty) {
-          }
-        }
-
-        const text = thisNode.textContent;
-        let tags: any[] = [];
-        if (thisNode instanceof HTMLElement && thisNode.dataset.tags) {
-          tags = JSON.parse(thisNode.dataset.tags);
-        }
-        if (
-          (!state[changed].searchQuery || state[changed].searchQuery === '') &&
-          (!state[changed].activeFilters ||
-            // @ts-ignore
-            !state[changed]!.activeFilters.length)
-        ) {
-          thisNode.classList.remove('hidden');
-          thisNode.classList.add('flex');
-          continue;
-        } else if (
-          state[changed].searchQuery?.length &&
-          !text
-            ?.toLowerCase()
-            // @ts-ignore
-            .includes(state[changed]!.searchQuery.toLowerCase())
-        ) {
-          thisNode.classList.add('hidden');
-          thisNode.classList.remove('flex');
-          continue;
-        } else if (state[changed].activeFilters?.length) {
-          let show = false;
-          // @ts-ignore
-          for (let j = 0; j < state[changed]!.activeFilters.length; j++) {
-            // @ts-ignore
-            const tag = state[changed]!.activeFilters[j];
-            if (
-              tags.find(
-                (t) =>
-                  t.category.toLowerCase() === tag.category.toLowerCase() &&
-                  t.tag.toLowerCase() === tag.tag.toLowerCase()
-              )
-            ) {
-              show = true;
-              break;
-            }
-          }
-          if (show) {
-            thisNode.classList.remove('hidden');
-            thisNode.classList.add('flex');
-          } else {
+          if (set && !setFiltersEmpty && !state[changed].sets.includes(set)) {
             thisNode.classList.remove('flex');
             thisNode.classList.add('hidden');
+            continue;
           }
-        } else {
-          //we can only get here if there's a text filter but no tag filters and the node is a match for the text query, so it should be shown
-          thisNode.classList.remove('hidden');
-          thisNode.classList.add('flex');
         }
+
+        // hide if its sets are hidden
+        if (state[changed].tags.length > 0) {
+          const tags =
+            thisNode instanceof HTMLElement && thisNode.dataset.tags
+              ? (JSON.parse(thisNode.dataset.tags) as Tag[])
+              : null;
+
+          if (tags) {
+            let match = false;
+            for (let i = 0; i < tags.length; i++) {
+              const tag = tags[i];
+              if (
+                state[changed].tags.find(
+                  (tf) =>
+                    tf.category.toLowerCase() === tag.category.toLowerCase() &&
+                    tf.tag.toLowerCase() === tag.tag.toLowerCase()
+                )
+              ) {
+                match = true;
+                break;
+              }
+            }
+
+            if (!match) {
+              thisNode.classList.remove('flex');
+              thisNode.classList.add('hidden');
+              continue;
+            }
+          }
+        }
+
+        // hide if the search query doesn't include any of its text
+        if (state[changed].searchQuery) {
+          const text = thisNode.textContent;
+
+          if (text) {
+            const match = text
+              .toLowerCase()
+              .includes(state[changed].searchQuery.toLowerCase());
+
+            if (!match) {
+              thisNode.classList.remove('flex');
+              thisNode.classList.add('hidden');
+              continue;
+            }
+          }
+        }
+
+        // display the annotation if it passed all the above checks
+        thisNode.classList.add('flex');
+        thisNode.classList.remove('hidden');
       }
     }
   });

--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -4,15 +4,16 @@ import Annotation from './Annotation.astro';
 
 export interface Props {
   playerId: string;
-  annotationSet: CollectionEntry<'annotations'>;
+  annotationSets: CollectionEntry<'annotations'>[];
   type: 'Audio' | 'Video';
 }
 
-const { playerId, annotationSet, type } = Astro.props;
+const { playerId, annotationSets, type } = Astro.props;
 
-const sortedAnnotations = annotationSet.data.annotations.sort(
-  (a: any, b: any) => a.start_time - b.start_time
-);
+const sortedAnnotations = annotationSets
+  .map((set) => set.data.annotations.map((ann) => ({ ...ann, set: set.id })))
+  .flat()
+  .sort((a: any, b: any) => a.start_time - b.start_time);
 ---
 
 <div class={`flex flex-col`}>
@@ -24,7 +25,7 @@ const sortedAnnotations = annotationSet.data.annotations.sort(
       id={playerId}
     >
       {
-        sortedAnnotations.map((ann: any) => {
+        sortedAnnotations.map((ann) => {
           return <Annotation ann={ann} playerId={playerId} />;
         })
       }
@@ -119,14 +120,24 @@ const sortedAnnotations = annotationSet.data.annotations.sort(
         }
       }
     }
-    //filter on text and tags
+    //filter on sets, text, and tags
     if (
       changed &&
       (state[changed].searchQuery != oldState[changed].searchQuery ||
-        state[changed].activeFilters != oldState[changed].activeFilters)
+        state[changed].activeFilters != oldState[changed].activeFilters ||
+        state[changed].sets.length != oldState[changed].sets.length)
     ) {
       for (let i = 0; i < annotationNodes.length; i++) {
         const thisNode = annotationNodes[i];
+
+        const setFiltersEmpty = state[changed].sets.length === 0;
+        const set = thisNode.getAttribute('data-set');
+
+        if (set) {
+          if (!setFiltersEmpty) {
+          }
+        }
+
         const text = thisNode.textContent;
         let tags: any[] = [];
         if (thisNode instanceof HTMLElement && thisNode.dataset.tags) {

--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -177,7 +177,7 @@ const sortedAnnotations = annotationSets
           if (text) {
             const match = text
               .toLowerCase()
-              .includes(state[changed].searchQuery.toLowerCase());
+              .includes(state[changed].searchQuery!.toLowerCase());
 
             if (!match) {
               thisNode.classList.remove('flex');

--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -11,7 +11,13 @@ export interface Props {
 const { playerId, annotationSets, type } = Astro.props;
 
 const sortedAnnotations = annotationSets
-  .map((set) => set.data.annotations.map((ann) => ({ ...ann, set: set.id })))
+  .map((set) =>
+    set.data.annotations.map((ann) => ({
+      ...ann,
+      set: set.id,
+      setName: set.data.set,
+    }))
+  )
   .flat()
   .sort((a: any, b: any) => a.start_time - b.start_time);
 ---
@@ -26,7 +32,13 @@ const sortedAnnotations = annotationSets
     >
       {
         sortedAnnotations.map((ann) => {
-          return <Annotation ann={ann} playerId={playerId} />;
+          return (
+            <Annotation
+              ann={ann}
+              playerId={playerId}
+              setName={annotationSets.length > 1 ? ann.setName : undefined}
+            />
+          );
         })
       }
     </div>

--- a/src/components/EventViewer/AnnotationUI/TagFilter.tsx
+++ b/src/components/EventViewer/AnnotationUI/TagFilter.tsx
@@ -133,11 +133,11 @@ const TagFilter = (props: TagFilterProps) => {
       <PopoverButton className='bg-white rounded-lg flex flex-row justify-center items-center gap-2 px-2 py-1.5 data-[open]:bg-blue-hover font-semibold'>
         <AdjustmentsVerticalIcon className='size-4' />
         <span>Filter</span>
-        {thisPlayer.tags && thisPlayer.tags.length ? (
+        {(thisPlayer.tags.length > 0 || thisPlayer.sets.length > 0) && (
           <div className='rounded-2xl px-1.5 py-0.5 flex items-center justify-center text-white bg-primary text-xs'>
-            {thisPlayer.tags.length}
+            {thisPlayer.tags.length + thisPlayer.sets.length}
           </div>
-        ) : null}
+        )}
       </PopoverButton>
       <PopoverPanel
         anchor='bottom end'
@@ -189,7 +189,7 @@ const TagFilter = (props: TagFilterProps) => {
         </div>
         <div className='flex flex-row justify-between w-full pb-2'>
           <p className='text-sm  font-semibold'>Tags</p>
-          {thisPlayer.tags && thisPlayer.tags.length ? (
+          {thisPlayer.tags.length > 0 && (
             <div className='bg-primary rounded-lg flex items-center justify-center gap-2 py-1 px-2 text-white cursor-default text-xs font-semibold'>
               <p>{`${thisPlayer.tags.length} filter${thisPlayer.tags.length > 1 ? 's' : ''} applied`}</p>
               <XMarkIcon
@@ -202,7 +202,7 @@ const TagFilter = (props: TagFilterProps) => {
                 }}
               />
             </div>
-          ) : null}
+          )}
         </div>
         {thisPlayer &&
           categories.map((cat, idx) => (

--- a/src/components/EventViewer/AnnotationUI/TagFilter.tsx
+++ b/src/components/EventViewer/AnnotationUI/TagFilter.tsx
@@ -65,7 +65,7 @@ const TagFilter = (props: TagFilterProps) => {
   const categories = Object.keys(allTags);
 
   const toggleTag = (tag: { category: string; tag: string }) => {
-    const current = thisPlayer.activeFilters || [];
+    const current = thisPlayer.tags || [];
     const updated = current?.find(
       (t) => t.category === tag.category && t.tag === tag.tag
     )
@@ -73,20 +73,20 @@ const TagFilter = (props: TagFilterProps) => {
       : [...current, tag];
     $pagePlayersState.setKey(playerId, {
       ...thisPlayer,
-      activeFilters: updated,
+      tags: updated,
     });
   };
 
   const toggleCategory = (category: string) => {
     const current =
-      thisPlayer.activeFilters?.filter(
+      thisPlayer.tags?.filter(
         (tag) => tag.category.toLowerCase() === category.toLowerCase()
       ) || [];
     if (current.length === allTags[category].tags.length) {
       //in this case, everything in the category is already checked, and we want to uncheck them
       $pagePlayersState.setKey(playerId, {
         ...thisPlayer,
-        activeFilters: thisPlayer.activeFilters?.filter(
+        tags: thisPlayer.tags?.filter(
           (tag) => tag.category.toLowerCase() != category.toLowerCase()
         ),
       });
@@ -95,9 +95,7 @@ const TagFilter = (props: TagFilterProps) => {
         category: category,
         tag: tag,
       }));
-      const active = thisPlayer.activeFilters
-        ? [...thisPlayer.activeFilters]
-        : [];
+      const active = thisPlayer.tags ? [...thisPlayer.tags] : [];
       allCategoryTags.forEach((tag) => {
         if (
           active.findIndex(
@@ -111,7 +109,7 @@ const TagFilter = (props: TagFilterProps) => {
       });
       $pagePlayersState.setKey(playerId, {
         ...thisPlayer,
-        activeFilters: active,
+        tags: active,
       });
     }
   };
@@ -135,9 +133,9 @@ const TagFilter = (props: TagFilterProps) => {
       <PopoverButton className='bg-white rounded-lg flex flex-row justify-center items-center gap-2 px-2 py-1.5 data-[open]:bg-blue-hover font-semibold'>
         <AdjustmentsVerticalIcon className='size-4' />
         <span>Filter</span>
-        {thisPlayer.activeFilters && thisPlayer.activeFilters.length ? (
+        {thisPlayer.tags && thisPlayer.tags.length ? (
           <div className='rounded-2xl px-1.5 py-0.5 flex items-center justify-center text-white bg-primary text-xs'>
-            {thisPlayer.activeFilters.length}
+            {thisPlayer.tags.length}
           </div>
         ) : null}
       </PopoverButton>
@@ -148,21 +146,23 @@ const TagFilter = (props: TagFilterProps) => {
         <div className='flex flex-row justify-between w-full pb-2'>
           {props.annotationSets.length > 1 && (
             <div className='w-full pb-2'>
-              <p className='text-sm font-semibold'>Sets</p>
-              {thisPlayer.sets.length > 1 && (
-                <div className='bg-primary rounded-lg flex items-center justify-center gap-2 py-1 px-2 text-white cursor-default text-xs font-semibold'>
-                  <p>{`${thisPlayer.sets.length} filter${thisPlayer.sets.length > 1 ? 's' : ''} applied`}</p>
-                  <XMarkIcon
-                    className='size-4 text-white hover:scale-105 cursor-pointer'
-                    onClick={() => {
-                      $pagePlayersState.setKey(playerId, {
-                        ...thisPlayer,
-                        sets: [],
-                      });
-                    }}
-                  />
-                </div>
-              )}
+              <div className='flex flex-row justify-between w-full pb-2'>
+                <p className='text-sm font-semibold'>Sets</p>
+                {thisPlayer.sets.length > 0 && (
+                  <div className='bg-primary rounded-lg flex items-center justify-center gap-2 py-1 px-2 text-white cursor-default text-xs font-semibold'>
+                    <p>{`${thisPlayer.sets.length} filter${thisPlayer.sets.length > 1 ? 's' : ''} applied`}</p>
+                    <XMarkIcon
+                      className='size-4 text-white hover:scale-105 cursor-pointer'
+                      onClick={() => {
+                        $pagePlayersState.setKey(playerId, {
+                          ...thisPlayer,
+                          sets: [],
+                        });
+                      }}
+                    />
+                  </div>
+                )}
+              </div>
               {props.annotationSets.map((set) => (
                 <div className='block' key={set.id}>
                   <div className='flex flex-row gap-3 py-1'>
@@ -188,15 +188,15 @@ const TagFilter = (props: TagFilterProps) => {
         </div>
         <div className='flex flex-row justify-between w-full pb-2'>
           <p className='text-sm  font-semibold'>Tags</p>
-          {thisPlayer.activeFilters && thisPlayer.activeFilters.length ? (
+          {thisPlayer.tags && thisPlayer.tags.length ? (
             <div className='bg-primary rounded-lg flex items-center justify-center gap-2 py-1 px-2 text-white cursor-default text-xs font-semibold'>
-              <p>{`${thisPlayer.activeFilters.length} filter${thisPlayer.activeFilters.length > 1 ? 's' : ''} applied`}</p>
+              <p>{`${thisPlayer.tags.length} filter${thisPlayer.tags.length > 1 ? 's' : ''} applied`}</p>
               <XMarkIcon
                 className='size-4 text-white hover:scale-105 cursor-pointer'
                 onClick={() => {
                   $pagePlayersState.setKey(playerId, {
                     ...thisPlayer,
-                    activeFilters: [],
+                    tags: [],
                   });
                 }}
               />
@@ -213,8 +213,8 @@ const TagFilter = (props: TagFilterProps) => {
                 <div className='flex flex-row gap-3 py-1'>
                   <Checkbox
                     checked={
-                      thisPlayer.activeFilters &&
-                      thisPlayer.activeFilters.filter(
+                      thisPlayer.tags &&
+                      thisPlayer.tags.filter(
                         (tag) =>
                           tag.category.toLowerCase() === cat.toLowerCase()
                       ).length === allTags[cat].tags.length
@@ -237,16 +237,16 @@ const TagFilter = (props: TagFilterProps) => {
                       key={idx}
                       tag={tag}
                       icon={
-                        thisPlayer.activeFilters &&
-                        thisPlayer.activeFilters?.findIndex(
+                        thisPlayer.tags &&
+                        thisPlayer.tags?.findIndex(
                           (t) => t.category == cat && t.tag == tag
                         ) != -1
                           ? CheckIcon
                           : undefined
                       }
                       className={
-                        thisPlayer.activeFilters &&
-                        thisPlayer.activeFilters?.findIndex(
+                        thisPlayer.tags &&
+                        thisPlayer.tags?.findIndex(
                           (t) => t.category === cat && t.tag === tag
                         ) != -1
                           ? 'outline outline-1 outline-black'

--- a/src/components/EventViewer/AnnotationUI/TagFilter.tsx
+++ b/src/components/EventViewer/AnnotationUI/TagFilter.tsx
@@ -96,12 +96,12 @@ const TagFilter = (props: TagFilterProps) => {
         className='flex flex-col w-[400px] bg-white drop-shadow-lg p-6 rounded-md mt-4'
       >
         <div className='flex flex-row justify-between w-full pb-2'>
-          <p className='text-lg font-bold'>Tags</p>
+          <p className='text-sm  font-semibold'>Tags</p>
           {thisPlayer.activeFilters && thisPlayer.activeFilters.length ? (
-            <div className='bg-primary rounded-lg flex items-center justify-center gap-2 py-1 px-2 text-white cursor-default'>
+            <div className='bg-primary rounded-lg flex items-center justify-center gap-2 py-1 px-2 text-white cursor-default text-xs font-semibold'>
               <p>{`${thisPlayer.activeFilters.length} filter${thisPlayer.activeFilters.length > 1 ? 's' : ''} applied`}</p>
               <XMarkIcon
-                className='size-4 text-white/70 hover:text-white hover:scale-105 cursor-pointer'
+                className='size-4 text-white hover:scale-105 cursor-pointer'
                 onClick={() => {
                   $pagePlayersState.setKey(playerId, {
                     ...thisPlayer,
@@ -116,7 +116,7 @@ const TagFilter = (props: TagFilterProps) => {
           categories.map((cat, idx) => (
             <React.Fragment key={idx}>
               {idx > 0 ? (
-                <div className='h-[1px] bg-gray-500 rounded-full w-full my-3' />
+                <div className='h-[1px] bg-gray-200 w-full my-3' />
               ) : null}
               <div className='flex flex-col gap-2' key={idx}>
                 <div className='flex flex-row gap-3 py-1'>
@@ -131,11 +131,11 @@ const TagFilter = (props: TagFilterProps) => {
                     onChange={() => {
                       toggleCategory(cat);
                     }}
-                    className='group size-6 rounded-md bg-white p-1 ring-1 ring-gray-500 ring-inset data-[checked]:bg-white'
+                    className='group size-4 bg-white rounded-sm data-[checked]:bg-primary p-0.5 ring-1 ring-gray-300 ring-inset data-[checked]:ring-primary'
                   >
-                    <CheckIcon className='hidden size-4 group-data-[checked]:block' />
+                    <CheckIcon className='hidden size-3 group-data-[checked]:block text-white' />
                   </Checkbox>
-                  <p className='capitalize font-bold'>
+                  <p className='capitalize font-semibold text-xs'>
                     {cat.replaceAll('_', '')}
                   </p>
                 </div>
@@ -158,7 +158,7 @@ const TagFilter = (props: TagFilterProps) => {
                         thisPlayer.activeFilters?.findIndex(
                           (t) => t.category === cat && t.tag === tag
                         ) != -1
-                          ? ' border-2 border-black'
+                          ? 'outline outline-1 outline-black'
                           : ''
                       }
                       onClick={() => {

--- a/src/components/EventViewer/AnnotationUI/TagFilter.tsx
+++ b/src/components/EventViewer/AnnotationUI/TagFilter.tsx
@@ -11,22 +11,70 @@ import {
   XMarkIcon,
 } from '@heroicons/react/24/outline';
 import { useStore } from '@nanostores/react';
-import React, { useMemo } from 'react';
+import { type CollectionEntry } from 'astro:content';
+import React, { useEffect, useMemo } from 'react';
 import { $pagePlayersState } from 'src/store.ts';
 
 export interface TagFilterProps {
   playerId: string;
-  tags: { [key: string]: { tags: string[]; color: string } };
+  projectData: CollectionEntry<'project'>;
+  annotationSets: CollectionEntry<'annotations'>[];
 }
 
 const TagFilter = (props: TagFilterProps) => {
-  const { playerId, tags } = props;
-  const categories = Object.keys(tags);
+  const { playerId } = props;
   const playerState = useStore($pagePlayersState);
   const thisPlayer = useMemo(
     () => playerState[playerId],
     [playerState, playerId]
   );
+
+  // enable the default set on first load
+  useEffect(() => {
+    if (thisPlayer.sets.length === 0) {
+      const defaultSet = props.annotationSets.find(
+        (s) => s.data.set === 'Default'
+      );
+
+      if (defaultSet) {
+        $pagePlayersState.setKey(playerId, {
+          ...thisPlayer,
+          sets: [defaultSet.id],
+        });
+      }
+    }
+  }, []);
+
+  const tagGroups = props.projectData.data.project.tags.tagGroups;
+
+  const allTags = useMemo(() => {
+    const tagsObj: { [key: string]: { tags: string[]; color: string } } = {};
+    thisPlayer.sets.forEach((uuid) => {
+      const setObj = props.annotationSets.find((s) => s.id === uuid);
+
+      setObj?.data.annotations.forEach((ann) => {
+        if (ann.tags && ann.tags.length) {
+          ann.tags.forEach((tag: { category: string; tag: string }) => {
+            const cat = tag.category.toLowerCase();
+            tagsObj[cat] ||= {
+              tags: [],
+              color:
+                tagGroups.find((grp) => grp.category.toLowerCase() === cat)
+                  ?.color || '#FFF',
+            };
+            if (!tagsObj[cat].tags.includes(tag.tag)) {
+              tagsObj[cat].tags.push(tag.tag);
+              tagsObj[cat].tags.sort();
+            }
+          });
+        }
+      });
+    });
+
+    return tagsObj;
+  }, [thisPlayer.sets]);
+
+  const categories = Object.keys(allTags);
 
   const toggleTag = (tag: { category: string; tag: string }) => {
     const current = thisPlayer.activeFilters || [];
@@ -46,7 +94,7 @@ const TagFilter = (props: TagFilterProps) => {
       thisPlayer.activeFilters?.filter(
         (tag) => tag.category.toLowerCase() === category.toLowerCase()
       ) || [];
-    if (current.length === tags[category].tags.length) {
+    if (current.length === allTags[category].tags.length) {
       //in this case, everything in the category is already checked, and we want to uncheck them
       $pagePlayersState.setKey(playerId, {
         ...thisPlayer,
@@ -55,7 +103,7 @@ const TagFilter = (props: TagFilterProps) => {
         ),
       });
     } else {
-      const allCategoryTags = tags[category].tags.map((tag) => ({
+      const allCategoryTags = allTags[category].tags.map((tag) => ({
         category: category,
         tag: tag,
       }));
@@ -80,6 +128,22 @@ const TagFilter = (props: TagFilterProps) => {
     }
   };
 
+  console.log(allTags);
+
+  const toggleSet = (setUuid: string) => {
+    if (thisPlayer.sets.includes(setUuid)) {
+      $pagePlayersState.setKey(playerId, {
+        ...thisPlayer,
+        sets: thisPlayer.sets.filter((s) => s !== setUuid),
+      });
+    } else {
+      $pagePlayersState.setKey(playerId, {
+        ...thisPlayer,
+        sets: [...thisPlayer.sets, setUuid],
+      });
+    }
+  };
+
   return (
     <Popover>
       <PopoverButton className='bg-white rounded-lg flex flex-row justify-center items-center gap-2 px-2 py-1.5 data-[open]:bg-blue-hover font-semibold'>
@@ -95,6 +159,49 @@ const TagFilter = (props: TagFilterProps) => {
         anchor='bottom end'
         className='flex flex-col w-[400px] bg-white drop-shadow-lg p-6 rounded-md mt-4'
       >
+        <div className='flex flex-row justify-between w-full pb-2'>
+          {props.annotationSets.length > 1 && (
+            <>
+              <div className='flex flex-row justify-between w-full pb-2'>
+                <p className='text-sm font-semibold'>Sets</p>
+                {thisPlayer.sets.length > 1 && (
+                  <div className='bg-primary rounded-lg flex items-center justify-center gap-2 py-1 px-2 text-white cursor-default text-xs font-semibold'>
+                    <p>{`${thisPlayer.sets.length} filter${thisPlayer.sets.length > 1 ? 's' : ''} applied`}</p>
+                    <XMarkIcon
+                      className='size-4 text-white hover:scale-105 cursor-pointer'
+                      onClick={() => {
+                        $pagePlayersState.setKey(playerId, {
+                          ...thisPlayer,
+                          activeFilters: [],
+                        });
+                      }}
+                    />
+                  </div>
+                )}
+                {props.annotationSets.map((set) => (
+                  <div className='block' key={set.id}>
+                    <div className='flex flex-row gap-3 py-1'>
+                      <Checkbox
+                        checked={
+                          thisPlayer.sets && thisPlayer.sets.includes(set.id)
+                        }
+                        onChange={() => {
+                          toggleSet(set.id);
+                        }}
+                        className='group size-4 bg-white rounded-sm data-[checked]:bg-primary p-0.5 ring-1 ring-gray-300 ring-inset data-[checked]:ring-primary'
+                      >
+                        <CheckIcon className='hidden size-3 group-data-[checked]:block text-white' />
+                      </Checkbox>
+                      <p className='capitalize font-semibold text-xs'>
+                        {set.data.set.replaceAll('_', '')}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
         <div className='flex flex-row justify-between w-full pb-2'>
           <p className='text-sm  font-semibold'>Tags</p>
           {thisPlayer.activeFilters && thisPlayer.activeFilters.length ? (
@@ -126,7 +233,7 @@ const TagFilter = (props: TagFilterProps) => {
                       thisPlayer.activeFilters.filter(
                         (tag) =>
                           tag.category.toLowerCase() === cat.toLowerCase()
-                      ).length === tags[cat].tags.length
+                      ).length === allTags[cat].tags.length
                     }
                     onChange={() => {
                       toggleCategory(cat);
@@ -140,9 +247,9 @@ const TagFilter = (props: TagFilterProps) => {
                   </p>
                 </div>
                 <div className='flex flex-row gap-2 flex-wrap'>
-                  {tags[cat].tags.map((tag, idx) => (
+                  {allTags[cat].tags.map((tag, idx) => (
                     <TagPill
-                      color={tags[cat].color}
+                      color={allTags[cat].color}
                       key={idx}
                       tag={tag}
                       icon={

--- a/src/components/EventViewer/AnnotationUI/TagFilter.tsx
+++ b/src/components/EventViewer/AnnotationUI/TagFilter.tsx
@@ -143,11 +143,12 @@ const TagFilter = (props: TagFilterProps) => {
         anchor='bottom end'
         className='flex flex-col w-[400px] bg-white drop-shadow-lg p-6 rounded-md mt-4'
       >
+        <p className='text-md font-semibold mb-4'>Filters</p>
         <div className='flex flex-row justify-between w-full pb-2'>
           {props.annotationSets.length > 1 && (
             <div className='w-full pb-2'>
               <div className='flex flex-row justify-between w-full pb-2'>
-                <p className='text-sm font-semibold'>Sets</p>
+                <p className='text-sm font-semibold'>Annotation Sets</p>
                 {thisPlayer.sets.length > 0 && (
                   <div className='bg-primary rounded-lg flex items-center justify-center gap-2 py-1 px-2 text-white cursor-default text-xs font-semibold'>
                     <p>{`${thisPlayer.sets.length} filter${thisPlayer.sets.length > 1 ? 's' : ''} applied`}</p>

--- a/src/components/EventViewer/AudioEvent.astro
+++ b/src/components/EventViewer/AudioEvent.astro
@@ -75,8 +75,8 @@ if (!currentSet) {
       }
       <Container className='w-full'>
         <AnnotationHeader
-          annotationSet={currentSet}
           playerId={avFileUuid}
+          annotationSets={annotationSets}
           type={event.data.item_type}
         />
       </Container>

--- a/src/components/EventViewer/AudioEvent.astro
+++ b/src/components/EventViewer/AudioEvent.astro
@@ -6,8 +6,6 @@ import RichText from '@components/RichText/index.astro';
 import Player from '@components/Player';
 import Annotations from './AnnotationUI/Annotations/index.astro';
 import AnnotationHeader from './AnnotationUI/Annotations/AnnotationHeader.astro';
-import { useStore } from '@nanostores/react';
-import { $pagePlayersState } from 'src/store';
 
 interface Props extends SlateEventNodeProps {
   annotationSets: CollectionEntry<'annotations'>[];
@@ -29,18 +27,12 @@ const {
 } = Astro.props;
 
 const avFileUuid = file || Object.keys(event.data.audiovisual_files)[0];
-
-const currentSet = annotationSets[0];
-
-if (!currentSet) {
-  throw new Error('Set not found.');
-}
 ---
 
 <div>
   <div class={`sticky top-[80px] z-10 ${!embed ? 'shadow' : ''}`}>
     <div class='flex flex-col gap-6 bg-gray-100 py-6'>
-      <Container className='w-full'>
+      <Container>
         {includes.includes('label') && <h1>{event.data.label}</h1>}
         {
           includes.includes('description') && event.data.description && (
@@ -60,7 +52,7 @@ if (!currentSet) {
                 data-player-url={url}
               >
                 {includes.includes('media') && (
-                  <Container className='w-full'>
+                  <Container>
                     <Player
                       url={url}
                       id={file}
@@ -73,7 +65,7 @@ if (!currentSet) {
             );
           })
       }
-      <Container className='w-full'>
+      <Container>
         <AnnotationHeader
           playerId={avFileUuid}
           annotationSets={annotationSets}
@@ -84,7 +76,7 @@ if (!currentSet) {
   </div>
   <Container>
     <Annotations
-      annotationSet={currentSet}
+      annotationSets={annotationSets}
       playerId={avFileUuid}
       type={event.data.item_type}
     />

--- a/src/components/EventViewer/VideoEvent.astro
+++ b/src/components/EventViewer/VideoEvent.astro
@@ -30,12 +30,6 @@ const {
 } = Astro.props;
 
 const avFileUuid = file || Object.keys(event.data.audiovisual_files)[0];
-
-const currentSet = annotationSets[0];
-
-if (!currentSet) {
-  throw new Error('Set not found.');
-}
 ---
 
 <Container className='flex flex-col gap-6 bg-gray-100 py-6'>
@@ -82,7 +76,7 @@ if (!currentSet) {
                 />
                 <Annotations
                   playerId={file}
-                  annotationSet={currentSet}
+                  annotationSets={annotationSets}
                   type={event.data.item_type}
                 />
               </div>

--- a/src/components/EventViewer/VideoEvent.astro
+++ b/src/components/EventViewer/VideoEvent.astro
@@ -77,7 +77,7 @@ if (!currentSet) {
               <div class='py-4'>
                 <AnnotationHeader
                   playerId={file}
-                  annotationSet={currentSet}
+                  annotationSets={annotationSets}
                   type={event.data.item_type}
                 />
                 <Annotations

--- a/src/components/EventViewer/index.astro
+++ b/src/components/EventViewer/index.astro
@@ -3,7 +3,6 @@ import { getCollection } from 'astro:content';
 import type { SlateEventNodeProps } from '@ty/slate';
 import AudioEvent from './AudioEvent.astro';
 import VideoEvent from './VideoEvent.astro';
-import type { Project } from '@ty/index';
 
 export interface Props extends Omit<SlateEventNodeProps, 'uuid'> {
   end?: number;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -70,7 +70,7 @@ const projectBy =
         searchQuery: '',
         activeFilters: [],
         annotationStarts: [],
-        setUuid: '',
+        sets: [],
         avFileUuid: '',
       });
     }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -68,7 +68,7 @@ const projectBy =
         showTags: true,
         currentAnnotation: 0,
         searchQuery: '',
-        activeFilters: [],
+        tags: [],
         annotationStarts: [],
         sets: [],
         avFileUuid: '',

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,7 +9,7 @@ export interface AnnotationState {
   showTags?: boolean;
   currentAnnotation?: number;
   searchQuery?: string;
-  activeFilters?: { category: string; tag: string }[];
+  tags: { category: string; tag: string }[];
   annotationStarts?: { start: number; end?: number }[];
   sets: string[];
   avFileUuid: string;

--- a/src/store.ts
+++ b/src/store.ts
@@ -11,7 +11,7 @@ export interface AnnotationState {
   searchQuery?: string;
   activeFilters?: { category: string; tag: string }[];
   annotationStarts?: { start: number; end?: number }[];
-  setUuid: string;
+  sets: string[];
   avFileUuid: string;
 }
 


### PR DESCRIPTION
# Summary

- updates the styling of the filter menu to match the latest from Figma
- adds set filtering (see below)
- adds a `rm -rf ./dist` prefix to the build step because `astro check` always tries to check the `dist` folder like Wile E. Coyote running into a wall, and runs out of memory doing so. This will make it less annoying for us to run the build process locally which will hopefully have the downstream effect of fewer build errors getting merged.

## Screenshot

(I don't know why every set in this event is called "default" but that's how it is in the JSON)

<img width="419" alt="Screenshot 2024-10-02 at 12 07 07 PM" src="https://github.com/user-attachments/assets/7199773a-4c64-43c1-a3b2-6ea02c2f2680">

## Testing

This feature handles a few different situations:

1. When an event has only one set (i.e. the default set), we don't show the set filters at all.
2. When the user hasn't selected any sets in the filter menu, we show all sets (this is consistent with the behavior of the tag filter)
3. When the user selects one or more sets, we only show annotations from those sets. The list of tags available for filtering should only include tags that appear in the currently selected sets.

Also, the annotations should display a gray box at the top with the name of the set the annotation came from. This box should *not* display if there's only one set.