### PR TITLE
Custom homepages with Table of Contents component

### DIFF
--- a/src/components/RichText/RichTextElement.astro
+++ b/src/components/RichText/RichTextElement.astro
@@ -1,5 +1,6 @@
 ---
 import EventViewer from '@components/EventViewer/index.astro';
+import TableOfContents from '@components/TableOfContents.astro';
 
 const { attributes, element } = Astro.props;
 
@@ -62,6 +63,13 @@ const getImageClass = (size: 'thumbnail' | 'medium' | 'large' | 'full') => {
         return (
           <div {...attributes} style={style}>
             <img src={element.url} class={getImageClass(element.size)} />
+            <slot />
+          </div>
+        );
+      case 'table-of-contents':
+        return (
+          <div {...attributes} style={style}>
+            <TableOfContents />
             <slot />
           </div>
         );

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,0 +1,45 @@
+---
+import { getEntry } from 'astro:content';
+import { dynamicConfig } from 'dynamic-astro-config';
+import { getOrder, getPages } from 'src/utils/pages';
+
+const projectData = await getEntry('project', 'project');
+
+const baseUrl = import.meta.env.PROD
+  ? projectData.data.project.slug
+  : dynamicConfig.base;
+
+const pageOrder = await getOrder();
+
+const pages = await getPages((page) => pageOrder.data.includes(page.id));
+
+// sort to match the order from pageOrder
+pages.sort((a, b) => {
+  const aIndex = pageOrder.data.indexOf(a.id);
+  const bIndex = pageOrder.data.indexOf(b.id);
+
+  if (aIndex > bIndex) {
+    return 1;
+  } else if (aIndex < bIndex) {
+    return -1;
+  }
+
+  return 0;
+});
+---
+
+<div class='py-4 flex flex-col gap-2'>
+  {
+    pages
+      .filter((page) => page.data.autogenerate.type != 'home')
+      .map((page) => (
+        <a
+          class='underline'
+          href={`/${baseUrl}/${page.data.autogenerate.enabled ? 'events' : 'pages'}/${page.id}`}
+        >
+          {page.data.title}
+        </a>
+      ))
+  }
+  <a class='underline' href={`/${baseUrl}/tags`}>Index</a>
+</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,54 +1,35 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import Container from '../components/Container.astro';
-import { dynamicConfig } from 'dynamic-astro-config';
 import { getEntry } from 'astro:content';
-import { getCollection } from 'astro:content';
-import { getOrder, getPages } from 'src/utils/pages';
+import TableOfContents from '@components/TableOfContents.astro';
+import { getPages } from 'src/utils/pages';
+import RichText from '@components/RichText/index.astro'
 
 const projectData = await getEntry('project', 'project');
-const pageOrder = await getOrder();
 
 const project = projectData.data.project;
 
-const baseUrl = import.meta.env.PROD
-  ? projectData.data.project.slug
-  : dynamicConfig.base;
+const homePageQuery = await getPages(
+  (p) => p.data.autogenerate.type === 'home' && !p.data.autogenerate.enabled
+);
 
-const pages = await getPages((page) => pageOrder.data.includes(page.id));
-
-// sort to match the order from pageOrder
-pages.sort((a, b) => {
-  const aIndex = pageOrder.data.indexOf(a.id);
-  const bIndex = pageOrder.data.indexOf(b.id);
-
-  if (aIndex > bIndex) {
-    return 1;
-  } else if (aIndex < bIndex) {
-    return -1;
-  }
-
-  return 0;
-});
+let homePage
+if (homePageQuery.length > 0) {
+  homePage = homePageQuery[0]
+}
 ---
 
 <Layout title={project.title} projectName={project.title}>
   <Container className='py-12 flex flex-col gap-6'>
-    <h1>{project.title}</h1>
-    <h2>{project.description}</h2>
-    <div class='py-12 flex flex-col gap-2'>
-      {
-        pages
-          .filter((page) => page.data.autogenerate.type != 'home')
-          .map((page) => (
-            <a
-              href={`/${baseUrl}/${page.data.autogenerate.enabled ? 'events' : 'pages'}/${page.id}`}
-            >
-              {page.data.title}
-            </a>
-          ))
-      }
-      <a href={`/${baseUrl}/tags`}>Index</a>
-    </div>
+    {homePage
+      ? (
+        <RichText nodes={homePage.data.content} />
+      )
+      : (
+        <h1>{project.title}</h1>
+        <h2>{project.description}</h2>
+        <TableOfContents />
+      )}
   </Container>
 </Layout>

--- a/src/utils/pages.ts
+++ b/src/utils/pages.ts
@@ -7,11 +7,13 @@ import { getCollection, getEntry, type CollectionEntry } from 'astro:content';
 // wrap around Astro's standard collections API while guaranteeing that we get
 // normal page objects only, and typecasting that way.
 
-interface PageCollectionEntry extends Omit<CollectionEntry<'pages'>, 'data'> {
+export interface PageCollectionEntry
+  extends Omit<CollectionEntry<'pages'>, 'data'> {
   data: Page;
 }
 
-interface OrderCollectionEntry extends Omit<CollectionEntry<'pages'>, 'data'> {
+export interface OrderCollectionEntry
+  extends Omit<CollectionEntry<'pages'>, 'data'> {
   data: string[];
 }
 


### PR DESCRIPTION
# Summary

- refactors the existing page list from the homepage into a new `TableOfContents` Astro component (with underline styling added to match Figma)
- updates the homepage to display a custom home page if the user has disabled autogeneration for their project's homepage; otherwise, we display the original hardcoded one

# Screenshot
<img width="494" alt="Screenshot 2024-10-02 at 4 38 25 PM" src="https://github.com/user-attachments/assets/d9c4ef69-ff2a-4339-8363-170195f5f5a7">
