### PR TITLE
Fix styling for embedded YouTube videos

### DIFF
--- a/src/style/player.css
+++ b/src/style/player.css
@@ -91,6 +91,11 @@
   background: #000;
 }
 
+/* YouTube embeds are contained in iframes instead of video elements */
+.player iframe {
+  height: 500px;
+}
+
 .player div {
   margin: auto;
 }


### PR DESCRIPTION
# Summary

This PR adds a minimum height to the `iframe` element that embedded YouTube videos come in. Previously, we applied styles to `video` elements which worked fine for non-YT videos, but YT comes in `iframes` instead.

They also have slightly different behavior than `video` tags when deciding their height - YT seems to stick to 150px unless you specifically set a `height` property, so here we set it to 500px.