### PR TITLE
Sidebar

### DIFF
--- a/src/components/EventViewer/AnnotationUI/OptionToggle.tsx
+++ b/src/components/EventViewer/AnnotationUI/OptionToggle.tsx
@@ -29,7 +29,7 @@ const OptionToggle: React.FC<OptionToggleProps> = (props) => {
     });
   };
 
-  const switchPosition = props.switchPosition || 'left';
+  const switchPosition = props.switchPosition || 'right';
 
   return (
     <Field className='flex flex-row gap-4'>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,6 +8,8 @@ import { getPages } from 'src/utils/pages';
 const projectData = await getEntry('project', 'project');
 const pages = await getPages();
 
+const { pageUuid } = Astro.params;
+
 const baseUrl = import.meta.env.PROD
   ? projectData.data.project.slug
   : dynamicConfig.base;
@@ -15,7 +17,7 @@ const baseUrl = import.meta.env.PROD
 
 <div class='bg-secondary text-white w-full h-[80px] py-6 sticky top-0 z-20'>
   <Container className='flex flex-row items-center gap-[52px]'>
-    <Sidebar baseUrl={baseUrl} client:only='react' pages={pages} />
+    <Sidebar baseUrl={baseUrl} client:load pages={pages} pageUuid={pageUuid} />
     <a href={`/${baseUrl}`} class='text-lg'>{projectData.data.project.title}</a>
   </Container>
 </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,8 +1,8 @@
 ---
-import { Bars3Icon } from '@heroicons/react/24/outline';
 import { getEntry } from 'astro:content';
 import { dynamicConfig } from 'dynamic-astro-config';
 import Container from './Container.astro';
+import Sidebar from './Sidebar';
 
 const projectData = await getEntry('project', 'project');
 
@@ -23,7 +23,7 @@ const { projectName } = Astro.props;
 
 <div class='bg-secondary text-white w-full h-[80px] py-6 sticky top-0 z-20'>
   <Container className='flex flex-row items-center gap-[52px]'>
-    <Bars3Icon className='w-8 h-8' />
+    <Sidebar />
     <a href={`/${baseUrl}`} class='text-lg'>{projectName}</a>
   </Container>
 </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,27 +3,19 @@ import { getEntry } from 'astro:content';
 import { dynamicConfig } from 'dynamic-astro-config';
 import Container from './Container.astro';
 import Sidebar from './Sidebar';
+import { getPages } from 'src/utils/pages';
 
 const projectData = await getEntry('project', 'project');
+const pages = await getPages();
 
 const baseUrl = import.meta.env.PROD
   ? projectData.data.project.slug
   : dynamicConfig.base;
-
-export interface Props {
-  projectName: string;
-  pages: {
-    title: string;
-    url: string;
-  }[];
-}
-
-const { projectName } = Astro.props;
 ---
 
 <div class='bg-secondary text-white w-full h-[80px] py-6 sticky top-0 z-20'>
   <Container className='flex flex-row items-center gap-[52px]'>
-    <Sidebar />
-    <a href={`/${baseUrl}`} class='text-lg'>{projectName}</a>
+    <Sidebar baseUrl={baseUrl} client:only='react' pages={pages} />
+    <a href={`/${baseUrl}`} class='text-lg'>{projectData.data.project.title}</a>
   </Container>
 </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,11 @@
+import { Bars3Icon } from '@heroicons/react/24/outline';
+
+const Sidebar: React.FC = () => {
+  return (
+    <>
+      <Bars3Icon className='w-8 h-8' />
+    </>
+  );
+};
+
+export default Sidebar;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,9 +1,56 @@
-import { Bars3Icon } from '@heroicons/react/24/outline';
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
+import { useState } from 'react';
+import { Transition } from '@headlessui/react';
+import type { PageCollectionEntry } from 'src/utils/pages.ts';
+import { ArrowReturnRight } from 'react-bootstrap-icons';
 
-const Sidebar: React.FC = () => {
+interface SidebarProps {
+  baseUrl: string;
+  pages: PageCollectionEntry[];
+}
+
+const Sidebar: React.FC<SidebarProps> = (props) => {
+  const [show, setShow] = useState(false);
+
   return (
     <>
-      <Bars3Icon className='w-8 h-8' />
+      <button onClick={() => setShow(!show)} type='button'>
+        <Bars3Icon className='w-8 h-8' />
+      </button>
+      {/* adds the ability to hide the sidebar by clicking outside it */}
+      {show && (
+        <div
+          className='absolute top-0 left-0 h-dvh w-dvw'
+          onClick={() => setShow(false)}
+        />
+      )}
+      <Transition show={show}>
+        <div className='shadow absolute top-0 left-0 h-dvh w-80 bg-white w-10 transition duration-200 ease-in-out data-[closed]:-translate-x-full text-black'>
+          <div className='flex w-full h-24 justify-end px-8'>
+            <button type='button' onClick={() => setShow(false)}>
+              <XMarkIcon className='w-8 h-8' />
+            </button>
+          </div>
+          <div className='flex flex-col gap-6 pb-8 px-8 font-semibold font-inter'>
+            {props.pages.map((page) => (
+              <p
+                key={page.id}
+                className='whitespace-nowrap overflow-hidden text-ellipsis'
+                title={page.data.title}
+              >
+                <a
+                  href={`/${props.baseUrl}/${page.data.autogenerate.enabled ? 'events' : 'pages'}/${page.id}`}
+                >
+                  {page.data.parent && (
+                    <ArrowReturnRight className='inline mr-2 relative bottom-[2px]' />
+                  )}
+                  {page.data.title}
+                </a>
+              </p>
+            ))}
+          </div>
+        </div>
+      </Transition>
     </>
   );
 };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,16 +1,27 @@
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Transition } from '@headlessui/react';
 import type { PageCollectionEntry } from 'src/utils/pages.ts';
-import { ArrowReturnRight } from 'react-bootstrap-icons';
 
 interface SidebarProps {
   baseUrl: string;
   pages: PageCollectionEntry[];
+  pageUuid?: string;
 }
 
 const Sidebar: React.FC<SidebarProps> = (props) => {
   const [show, setShow] = useState(false);
+
+  const homeUuid = useMemo(
+    () => props.pages.find((p) => p.data.autogenerate.type === 'home')?.id,
+    [props.pages]
+  );
+
+  // highlight the current page
+  // if there's no page slug, that means we're on the homepage
+  const isSelected = (page: PageCollectionEntry) => {
+    return page.id === (props.pageUuid || homeUuid);
+  };
 
   return (
     <>
@@ -25,30 +36,27 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
         />
       )}
       <Transition show={show}>
-        <div className='shadow absolute top-0 left-0 h-dvh w-80 bg-white w-10 transition duration-200 ease-in-out data-[closed]:-translate-x-full text-black'>
+        <div className='shadow absolute top-0 left-0 h-dvh w-80 bg-white w-10 transition duration-200 ease-in-out data-[closed]:-translate-x-full text-black text-sm'>
           <div className='flex w-full h-24 justify-end px-8'>
             <button type='button' onClick={() => setShow(false)}>
               <XMarkIcon className='w-8 h-8' />
             </button>
           </div>
-          <div className='flex flex-col gap-6 pb-8 px-8 font-semibold font-inter'>
-            {props.pages.map((page) => (
-              <p
-                key={page.id}
-                className='whitespace-nowrap overflow-hidden text-ellipsis'
-                title={page.data.title}
-              >
-                <a
-                  href={`/${props.baseUrl}/${page.data.autogenerate.enabled ? 'events' : 'pages'}/${page.id}`}
+          {props.pages.map((page) => (
+            <a
+              href={`/${props.baseUrl}/${page.data.autogenerate.enabled ? 'events' : 'pages'}/${page.id}`}
+            >
+              <div className='p-4 hover:bg-blue-hover'>
+                <p
+                  key={page.id}
+                  className={`${isSelected(page) ? 'font-bold' : ''} ${page.data.parent ? 'ml-6' : ''}`}
+                  title={page.data.title}
                 >
-                  {page.data.parent && (
-                    <ArrowReturnRight className='inline mr-2 relative bottom-[2px]' />
-                  )}
                   {page.data.title}
-                </a>
-              </p>
-            ))}
-          </div>
+                </p>
+              </div>
+            </a>
+          ))}
         </div>
       </Transition>
     </>

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -9,23 +9,7 @@ const baseUrl = import.meta.env.PROD
   ? projectData.data.project.slug
   : dynamicConfig.base;
 
-const pageOrder = await getOrder();
-
-const pages = await getPages((page) => pageOrder.data.includes(page.id));
-
-// sort to match the order from pageOrder
-pages.sort((a, b) => {
-  const aIndex = pageOrder.data.indexOf(a.id);
-  const bIndex = pageOrder.data.indexOf(b.id);
-
-  if (aIndex > bIndex) {
-    return 1;
-  } else if (aIndex < bIndex) {
-    return -1;
-  }
-
-  return 0;
-});
+const pages = await getPages();
 ---
 
 <div class='py-4 flex flex-col gap-2'>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,14 +11,9 @@ const projectData = await getEntry('project', 'project');
 interface Props {
   background?: string;
   title?: string;
-  projectName?: string;
 }
 
-const {
-  background,
-  title = projectData.data.project.title,
-  projectName = projectData.data.project.title,
-} = Astro.props;
+const { background, title = projectData.data.project.title } = Astro.props;
 
 const projectBy =
   projectData.data.project.authors || projectData.data.project.creator;
@@ -43,7 +38,7 @@ const projectBy =
     <title>{title}</title>
   </head>
   <body class='flex h-full flex-col mx-auto' transition:animate='initial'>
-    <Header projectName={projectName} pages={[]} />
+    <Header />
     <main class=`min-h-[calc(100dvh_-160px)] text-black bg-${background}`>
       <slot />
     </main>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,7 +20,7 @@ if (homePageQuery.length > 0) {
 }
 ---
 
-<Layout title={project.title} projectName={project.title}>
+<Layout title={project.title}>
   <Container className='py-12 flex flex-col gap-6'>
     {homePage
       ? (

--- a/src/pages/pages/[pageUuid].astro
+++ b/src/pages/pages/[pageUuid].astro
@@ -3,7 +3,6 @@ import type { GetStaticPaths } from 'astro';
 import { dynamicConfig } from 'dynamic-astro-config';
 import Layout from '@layouts/Layout.astro';
 import Container from '@components/Container.astro';
-import { getCollection } from 'astro:content';
 import { getEntry } from 'astro:content';
 import RichText from '../../components/RichText/index.astro';
 import { getPage, getPages } from 'src/utils/pages';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -130,6 +130,7 @@ export type Page = {
   created_by: string;
   title: string;
   parent?: string;
+  slug?: string;
   updated_at: string;
   updated_by: string;
   autogenerate: AutoGenerate;

--- a/src/utils/pages.ts
+++ b/src/utils/pages.ts
@@ -22,12 +22,34 @@ export interface OrderCollectionEntry
 export const getPages = async (
   filterCallback?: (page: PageCollectionEntry) => boolean
 ) => {
+  const pageOrder = await getOrder();
+
   const results = await getCollection('pages', (page) => {
     if (page.id === 'order') {
       return false;
     }
 
+    // skip pages that aren't mentioned in the order file
+    // something has gone terribly wrong if this happens!
+    if (!pageOrder.data.includes(page.id)) {
+      return false;
+    }
+
     return filterCallback ? filterCallback(page as PageCollectionEntry) : true;
+  });
+
+  // sort to match the order from pageOrder
+  results.sort((a, b) => {
+    const aIndex = pageOrder.data.indexOf(a.id);
+    const bIndex = pageOrder.data.indexOf(b.id);
+
+    if (aIndex > bIndex) {
+      return 1;
+    } else if (aIndex < bIndex) {
+      return -1;
+    }
+
+    return 0;
   });
 
   return results as PageCollectionEntry[];


### PR DESCRIPTION
# Summary

This PR adds functionality to the (previously nonfunctional) hamburger icon. The menu slides out using Headless UI's `Transition` component and displays a list of pages using the design from Figma.

It also does some refactoring to move page sorting logic into the `getPages` helper function and out of components, so we can always assume that a given `pages` array is already sorted.

## Screenshot

(I don't know why my cursor didn't change to a pointer on hover, that's an issue with the screen recording)

https://github.com/user-attachments/assets/f223d29e-0890-4fde-996a-b70221c69acf

