### PR TITLE
Event clip embeds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "react": "^18.3.1",
         "react-bootstrap-icons": "^1.11.4",
         "react-dom": "^18.3.1",
-        "react-player": "^2.16.0",
+        "react-player": "3.0.0-canary.4",
         "slate": "^0.103.0",
         "snake-case": "^4.0.0",
         "tailwindcss": "^3.4.9"
@@ -7929,9 +7929,10 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-player": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.16.0.tgz",
-      "integrity": "sha512-mAIPHfioD7yxO0GNYVFD1303QFtI3lyyQZLY229UEAp/a10cSW+hPcakg0Keq8uWJxT2OiT/4Gt+Lc9bD6bJmQ==",
+      "version": "3.0.0-canary.4",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-3.0.0-canary.4.tgz",
+      "integrity": "sha512-qaBI01hUzNic+TAbPOUMI0x2XItmmRsmRMWogescsb2RSsKVRnDJHFHmFqeO8Qvx+7RwWVw+p78JR0dTvBdHsQ==",
+      "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.0.0",
         "load-script": "^1.0.0",
@@ -7940,7 +7941,9 @@
         "react-fast-compare": "^3.0.1"
       },
       "peerDependencies": {
-        "react": ">=16.6.0"
+        "@types/react": "^17.0.0 || ^18",
+        "react": "^17.0.2 || ^18",
+        "react-dom": "^17.0.2 || ^18"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react": "^18.3.1",
     "react-bootstrap-icons": "^1.11.4",
     "react-dom": "^18.3.1",
-    "react-player": "^2.16.0",
+    "react-player": "3.0.0-canary.4",
     "slate": "^0.103.0",
     "snake-case": "^4.0.0",
     "tailwindcss": "^3.4.9"

--- a/src/components/EventViewer/AnnotationUI/AnnotationHeader.astro
+++ b/src/components/EventViewer/AnnotationUI/AnnotationHeader.astro
@@ -1,6 +1,5 @@
 ---
 import AnnotationSettingsMenu from './AnnotationSettingsMenu';
-import OptionToggle from './OptionToggle';
 import TagFilter from './TagFilter';
 import TextSearch from './TextSearch';
 import { getEntry } from 'astro:content';

--- a/src/components/EventViewer/AnnotationUI/AnnotationHeader.astro
+++ b/src/components/EventViewer/AnnotationUI/AnnotationHeader.astro
@@ -1,60 +1,52 @@
 ---
-import AnnotationSettingsMenu from "./AnnotationSettingsMenu";
-import OptionToggle from "./OptionToggle";
-import TagFilter from "./TagFilter";
-import TextSearch from "./TextSearch";
-import { getEntry } from "astro:content";
-import type { CollectionEntry } from "astro:content";
+import AnnotationSettingsMenu from './AnnotationSettingsMenu';
+import OptionToggle from './OptionToggle';
+import TagFilter from './TagFilter';
+import TextSearch from './TextSearch';
+import { getEntry } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 
 interface Props {
-  annotationSets: CollectionEntry<'annotations'>[],
-  playerId: string,
-  type: 'Audio' | 'Video'
+  annotationSets: CollectionEntry<'annotations'>[];
+  playerId: string;
+  type: 'Audio' | 'Video';
 }
 
 const projectData = await getEntry('project', 'project');
 
 const { annotationSets, playerId, type } = Astro.props;
-
 ---
+
 <div>
   <div
     class={`flex flex-row w-full justify-between items-center ${type === 'Video' ? 'flex-col gap-3' : 'flex-row items-center'}`}
   >
-    <div class={`flex flex-row justify-between ${type === 'Video' ? 'w-full' : ''}`}>
+    <div
+      class={`flex flex-row justify-between ${type === 'Video' ? 'w-full' : ''}`}
+    >
       <h3 class='font-bold text-lg'>Annotations</h3>
       {
         type === 'Video' && (
-          <AnnotationSettingsMenu playerId={playerId} client:only="react" />
+          <AnnotationSettingsMenu playerId={playerId} client:only='react' />
         )
       }
     </div>
-    { type === 'Video' && <div class="h-1 border-t border-gray-200 w-full" />}
-    <div class={`flex flex-row gap-8 items-center ${type === 'Video' ? 'w-full justify-between pb-4 z-10 shadow-[0px_4px_2px_-2px_#00000040]' : ''}`}>
-    {
-      type === 'Audio' && (
-        <OptionToggle
-          client:only="react"
-          label="Autoscroll"
-          playerId={playerId}
-          property="autoScroll"
-        />
-        <OptionToggle
-          client:only="react"
-          label="Show Tags"
-          playerId={playerId}
-          property="showTags"
-        />
-        <OptionToggle
-          client:only="react"
-          label="Snap to Annotations"
-          playerId={playerId}
-          property="snapToAnnotations"
-        />
-      )
-    }
+    {type === 'Video' && <div class='h-1 border-t border-gray-200 w-full' />}
+    <div
+      class={`flex flex-row gap-8 items-center ${type === 'Video' ? 'w-full justify-between pb-4 z-10 shadow-[0px_4px_2px_-2px_#00000040]' : ''}`}
+    >
       <TextSearch playerId={playerId} client:only='react' />
-      <TagFilter annotationSets={annotationSets} playerId={playerId} projectData={projectData} client:only='react' />
+      <TagFilter
+        annotationSets={annotationSets}
+        playerId={playerId}
+        projectData={projectData}
+        client:only='react'
+      />
+      {
+        type === 'Audio' && (
+          <AnnotationSettingsMenu playerId={playerId} client:only='react' />
+        )
+      }
     </div>
   </div>
 </div>

--- a/src/components/EventViewer/AnnotationUI/Annotations/AnnotationNanostorePopulator.tsx
+++ b/src/components/EventViewer/AnnotationUI/Annotations/AnnotationNanostorePopulator.tsx
@@ -9,6 +9,7 @@ import { useEffect } from 'react';
 interface Props {
   annotations: DisplayedAnnotation[];
   playerId: string;
+  isEmbed?: boolean;
 }
 
 const AnnotationNanostorePopulator: React.FC<Props> = (props) => {
@@ -19,8 +20,9 @@ const AnnotationNanostorePopulator: React.FC<Props> = (props) => {
       ...store[props.playerId],
       annotations: [...props.annotations],
       filteredAnnotations: [...props.annotations.map((ann) => ann.uuid)],
+      isEmbed: props.isEmbed,
     });
-  }, [props.annotations, props.playerId]);
+  }, [props.annotations, props.playerId, props.isEmbed]);
 
   return <></>;
 };

--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -8,10 +8,10 @@ export interface Props {
   playerId: string;
   annotationSets: CollectionEntry<'annotations'>[];
   type: 'Audio' | 'Video';
-  embed?: boolean;
+  isEmbed?: boolean;
 }
 
-const { annotationSets, embed, playerId, type } = Astro.props;
+const { annotationSets, isEmbed, playerId, type } = Astro.props;
 
 const sortedAnnotations = annotationSets
   .map((set) =>
@@ -34,6 +34,7 @@ const sortedAnnotations = annotationSets
     <AnnotationNanostorePopulator
       annotations={sortedAnnotations}
       playerId={playerId}
+      isEmbed={isEmbed}
       client:only='react'
     />
     <div
@@ -114,12 +115,6 @@ const sortedAnnotations = annotationSets
       `.eventContainer[data-player-id="${changed}"]`
     );
 
-    console.log(
-      document
-        .querySelector(`.eventContainer[data-player-id]`)
-        ?.getAttribute('data-player-id')
-    );
-
     if (!eventContainerEl) {
       console.error(`No event container found for ${changed}`);
       return null;
@@ -146,9 +141,18 @@ const sortedAnnotations = annotationSets
     if (typeof current === 'number' && current >= 0) {
       const activeNode = annotationNodes[current] as HTMLElement;
 
-      if (state[changed].autoScroll && activeNode.parentElement) {
-        const offsetTop = activeNode.offsetTop;
-        eventContainerEl.scroll({ top: offsetTop - 200, behavior: 'smooth' });
+      if (state[changed].autoScroll) {
+        // scroll the parent element if we're in an embed
+        if (state[changed].isEmbed) {
+          const offsetTop = activeNode.offsetTop;
+          eventContainerEl.scroll({
+            top: offsetTop - eventContainerEl.clientHeight / 3,
+            behavior: 'smooth',
+          });
+        // otherwise, scroll the whole page
+        } else {
+          activeNode.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
       }
 
       activeNode.classList.add(activeBackground);

--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -38,8 +38,9 @@ const sortedAnnotations = annotationSets
       client:only='react'
     />
     <div
-      class={` ${type === 'Video' ? 'overflow-y-scroll max-h-[calc(100dvh_-360px)]' : ''}`}
+      class={`${type === 'Video' ? 'overflow-y-scroll max-h-[510px] video videoAnnotationContainer' : ''}`}
       id={playerId}
+      data-player-id={playerId}
     >
       {
         sortedAnnotations.map((ann) => {
@@ -144,12 +145,24 @@ const sortedAnnotations = annotationSets
       if (state[changed].autoScroll) {
         // scroll the parent element if we're in an embed
         if (state[changed].isEmbed) {
+          const videoContainerEl = document.querySelector(
+            `.videoAnnotationContainer[data-player-id="${changed}"]`
+          );
           const offsetTop = activeNode.offsetTop;
-          eventContainerEl.scroll({
-            top: offsetTop - eventContainerEl.clientHeight / 3,
-            behavior: 'smooth',
-          });
-        // otherwise, scroll the whole page
+
+          // we need to scroll a different container if we're in an embedded video event
+          if (videoContainerEl) {
+            videoContainerEl.scroll({
+              top: offsetTop - videoContainerEl.clientHeight,
+              behavior: 'smooth',
+            });
+          } else {
+            eventContainerEl.scroll({
+              top: offsetTop - eventContainerEl.clientHeight / 3,
+              behavior: 'smooth',
+            });
+          }
+          // otherwise, scroll the whole page
         } else {
           activeNode.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }

--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -113,33 +113,28 @@ const sortedAnnotations = annotationSets
       return null;
     }
 
-    if (
-      Math.floor(state[changed].position * 1000) % 7 ===
-      0 //this is just meant to get it firing at a reasonable interval...should find a less random way
-    ) {
-      const startTimes = state[changed].annotationStarts;
-      const current = startTimes?.findIndex((time, idx) => {
-        if (typeof time.end === 'number') {
-          return (
-            time.start <= state[changed].position &&
-            time.end > state[changed].position
-          );
-        }
-        return idx < startTimes.length - 1
-          ? time.start <= state[changed].position &&
-              startTimes[idx + 1].start > state[changed].position
-          : time.start <= state[changed].position;
-      });
-      if (typeof current === 'number' && current >= 0) {
-        const activeNode = annotationNodes[current];
-        if (state[changed].autoScroll) {
-          activeNode.scrollIntoView({ block: 'center', behavior: 'smooth' });
-        }
-        activeNode.classList.add(activeBackground);
-        for (let i = 0; i < annotationNodes.length; i++) {
-          if (i !== current) {
-            annotationNodes[i].classList.remove(activeBackground);
-          }
+    const startTimes = state[changed].annotationStarts;
+    const current = startTimes?.findIndex((time, idx) => {
+      if (typeof time.end === 'number') {
+        return (
+          time.start <= state[changed].position &&
+          time.end > state[changed].position
+        );
+      }
+      return idx < startTimes.length - 1
+        ? time.start <= state[changed].position &&
+            startTimes[idx + 1].start > state[changed].position
+        : time.start <= state[changed].position;
+    });
+    if (typeof current === 'number' && current >= 0) {
+      const activeNode = annotationNodes[current];
+      if (state[changed].autoScroll) {
+        activeNode.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      }
+      activeNode.classList.add(activeBackground);
+      for (let i = 0; i < annotationNodes.length; i++) {
+        if (i !== current) {
+          annotationNodes[i].classList.remove(activeBackground);
         }
       }
     }

--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -8,9 +8,10 @@ export interface Props {
   playerId: string;
   annotationSets: CollectionEntry<'annotations'>[];
   type: 'Audio' | 'Video';
+  embed?: boolean;
 }
 
-const { playerId, annotationSets, type } = Astro.props;
+const { annotationSets, embed, playerId, type } = Astro.props;
 
 const sortedAnnotations = annotationSets
   .map((set) =>
@@ -26,7 +27,7 @@ const sortedAnnotations = annotationSets
   ) as DisplayedAnnotation[];
 ---
 
-<div class={`flex flex-col`}>
+<div class='flex flex-col'>
   <div
     class=`top-[300px] overflow-y-visible w-full ${type === 'Audio' ? 'sticky' : ''}`
   >
@@ -36,7 +37,7 @@ const sortedAnnotations = annotationSets
       client:only='react'
     />
     <div
-      class={`${type === 'Video' ? 'overflow-y-scroll max-h-[calc(100dvh_-360px)]' : ''}`}
+      class={` ${type === 'Video' ? 'overflow-y-scroll max-h-[calc(100dvh_-360px)]' : ''}`}
       id={playerId}
     >
       {
@@ -57,12 +58,6 @@ const sortedAnnotations = annotationSets
 <script>
   import { $pagePlayersState } from 'src/store.ts';
 
-  const annotationPlayNodes = document.getElementsByClassName('playAnnotation');
-  const annotationNodes = document.getElementsByClassName('annotationNode');
-  const annotationTagNodes = document.getElementsByClassName('annotationTags');
-
-  const activeBackground = '!bg-blue-hover';
-
   const hideNode = (node: HTMLElement | Element) => {
     node.classList.add('hidden');
     node.classList.remove('flex');
@@ -73,15 +68,17 @@ const sortedAnnotations = annotationSets
     node.classList.remove('hidden');
   };
 
+  const activeBackground = '!bg-blue-hover';
+
+  const annotationPlayNodes = document.querySelectorAll(`.playAnnotation`);
+
   for (let i = 0; i < annotationPlayNodes.length; i++) {
-    const thisNode = annotationPlayNodes[i];
-    if (
-      thisNode instanceof HTMLElement &&
-      thisNode.dataset.start &&
-      thisNode.dataset.playerId
-    ) {
+    const thisNode = annotationPlayNodes[i] as HTMLElement;
+
+    if (thisNode.dataset.start && thisNode.dataset.playerId) {
       const annotationStartsNew =
-        $pagePlayersState.get()[thisNode.dataset.playerId].annotationStarts;
+        $pagePlayersState.get()[thisNode.dataset.playerId]?.annotationStarts;
+
       if (annotationStartsNew) {
         annotationStartsNew.push({
           start: Math.floor(Number(thisNode.dataset.start)),
@@ -113,6 +110,26 @@ const sortedAnnotations = annotationSets
       return null;
     }
 
+    const eventContainerEl = document.querySelector(
+      `.eventContainer[data-player-id="${changed}"]`
+    );
+
+    console.log(
+      document
+        .querySelector(`.eventContainer[data-player-id]`)
+        ?.getAttribute('data-player-id')
+    );
+
+    if (!eventContainerEl) {
+      console.error(`No event container found for ${changed}`);
+      return null;
+    }
+
+    const annotationNodes =
+      eventContainerEl.querySelectorAll(`.annotationNode`);
+    const annotationTagNodes =
+      eventContainerEl.querySelectorAll(`.annotationTags`);
+
     const startTimes = state[changed].annotationStarts;
     const current = startTimes?.findIndex((time, idx) => {
       if (typeof time.end === 'number') {
@@ -127,11 +144,15 @@ const sortedAnnotations = annotationSets
         : time.start <= state[changed].position;
     });
     if (typeof current === 'number' && current >= 0) {
-      const activeNode = annotationNodes[current];
-      if (state[changed].autoScroll) {
-        activeNode.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      const activeNode = annotationNodes[current] as HTMLElement;
+
+      if (state[changed].autoScroll && activeNode.parentElement) {
+        const offsetTop = activeNode.offsetTop;
+        eventContainerEl.scroll({ top: offsetTop - 200, behavior: 'smooth' });
       }
+
       activeNode.classList.add(activeBackground);
+
       for (let i = 0; i < annotationNodes.length; i++) {
         if (i !== current) {
           annotationNodes[i].classList.remove(activeBackground);
@@ -152,7 +173,7 @@ const sortedAnnotations = annotationSets
       }
     }
 
-    //filter on sets, text, and tags
+    // filter on sets, text, and tags
     for (let i = 0; i < annotationNodes.length; i++) {
       const node = annotationNodes[i];
 

--- a/src/components/EventViewer/AnnotationUI/TextSearch.tsx
+++ b/src/components/EventViewer/AnnotationUI/TextSearch.tsx
@@ -1,7 +1,7 @@
 import { Input } from '@headlessui/react';
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import { useStore } from '@nanostores/react';
-import { $pagePlayersState } from 'src/store.ts';
+import { $pagePlayersState, setSearchFilter } from 'src/store.ts';
 
 export interface TextSearchProps {
   playerId: string;
@@ -10,12 +10,11 @@ export interface TextSearchProps {
 const TextSearch = (props: TextSearchProps) => {
   const { playerId } = props;
   const pagePlayers = useStore($pagePlayersState);
+
   const handleChange = (e: any) => {
-    $pagePlayersState.setKey(playerId, {
-      ...pagePlayers[playerId],
-      searchQuery: e.target.value,
-    });
+    setSearchFilter(e.target.value, playerId);
   };
+
   return (
     <div className='flex flex-row rounded-lg py-1.5 px-3 bg-white items-center gap-3 border-solid border border-gray-200'>
       <MagnifyingGlassIcon className='h-6 w-6' />

--- a/src/components/EventViewer/AudioEvent.astro
+++ b/src/components/EventViewer/AudioEvent.astro
@@ -58,6 +58,8 @@ const avFileUuid = file || Object.keys(event.data.audiovisual_files)[0];
                       id={file}
                       client:only='react'
                       type={event.data.item_type}
+                      start={start}
+                      end={end}
                     />
                   </Container>
                 )}

--- a/src/components/EventViewer/AudioEvent.astro
+++ b/src/components/EventViewer/AudioEvent.astro
@@ -12,7 +12,7 @@ interface Props extends SlateEventNodeProps {
   event: CollectionEntry<'events'>;
   // UUID of the audiovisual file, for embedded events
   file?: string;
-  embed?: boolean;
+  isEmbed?: boolean;
   playerId: string;
 }
 
@@ -24,17 +24,17 @@ const {
   event,
   file,
   annotationSets,
-  embed,
+  isEmbed,
   playerId,
 } = Astro.props;
 ---
 
 <div>
   <div
-    class={`sticky ${includes.includes('label') ? 'top-[80px]' : 'top-0'} z-10 ${!embed ? 'shadow' : ''}`}
+    class={`sticky ${includes.includes('label') ? 'top-[80px]' : 'top-0'} z-10 ${!isEmbed ? 'shadow' : ''}`}
   >
     <div class='flex flex-col gap-6 bg-gray-100 py-6'>
-      <ConditionalContainer condition={!embed}>
+      <ConditionalContainer condition={!isEmbed}>
         {includes.includes('label') && <h1>{event.data.label}</h1>}
         {
           includes.includes('description') && event.data.description && (
@@ -54,7 +54,7 @@ const {
                 data-player-url={url}
               >
                 {includes.includes('media') && (
-                  <ConditionalContainer condition={!embed}>
+                  <ConditionalContainer condition={!isEmbed}>
                     <Player
                       url={url}
                       id={playerId}
@@ -69,7 +69,7 @@ const {
             );
           })
       }
-      <ConditionalContainer condition={!embed}>
+      <ConditionalContainer condition={!isEmbed}>
         <AnnotationHeader
           playerId={playerId}
           annotationSets={annotationSets}
@@ -78,9 +78,10 @@ const {
       </ConditionalContainer>
     </div>
   </div>
-  <ConditionalContainer condition={!embed}>
+  <ConditionalContainer condition={!isEmbed}>
     <Annotations
       annotationSets={annotationSets}
+      isEmbed={isEmbed}
       playerId={playerId}
       type={event.data.item_type}
     />

--- a/src/components/EventViewer/AudioEvent.astro
+++ b/src/components/EventViewer/AudioEvent.astro
@@ -10,15 +10,14 @@ import ConditionalContainer from './ConditionalContainer.astro';
 interface Props extends SlateEventNodeProps {
   annotationSets: CollectionEntry<'annotations'>[];
   event: CollectionEntry<'events'>;
-  // UUID of the audiovisual file, for embedded events
-  file?: string;
+  file: string;
   isEmbed?: boolean;
   playerId: string;
 }
 
 const {
   // include everything by default
-  includes = ['media', 'annotations', 'label', 'description'],
+  includes,
   start,
   end,
   event,
@@ -27,6 +26,8 @@ const {
   isEmbed,
   playerId,
 } = Astro.props;
+
+const url = event.data.audiovisual_files[file].file_url;
 ---
 
 <div>
@@ -42,33 +43,26 @@ const {
           )
         }
       </ConditionalContainer>
-      {
-        (includes.includes('annotations') || includes.includes('media')) &&
-          Object.keys(event.data.audiovisual_files).map((file: string) => {
-            const url: string = event.data.audiovisual_files[file].file_url;
-
-            return (
-              <div
-                class='mediaContainer gap-4 flex flex-col'
-                data-player-id={playerId}
-                data-player-url={url}
-              >
-                {includes.includes('media') && (
-                  <ConditionalContainer condition={!isEmbed}>
-                    <Player
-                      url={url}
-                      id={playerId}
-                      client:only='react'
-                      type={event.data.item_type}
-                      start={start}
-                      end={end}
-                    />
-                  </ConditionalContainer>
-                )}
-              </div>
-            );
-          })
-      }
+      <div
+        class='mediaContainer gap-4 flex flex-col'
+        data-player-id={playerId}
+        data-player-url={url}
+      >
+        {
+          includes.includes('media') && (
+            <ConditionalContainer condition={!isEmbed}>
+              <Player
+                url={url}
+                id={playerId}
+                client:only='react'
+                type={event.data.item_type}
+                start={start}
+                end={end}
+              />
+            </ConditionalContainer>
+          )
+        }
+      </div>
       <ConditionalContainer condition={!isEmbed}>
         <AnnotationHeader
           playerId={playerId}

--- a/src/components/EventViewer/AudioEvent.astro
+++ b/src/components/EventViewer/AudioEvent.astro
@@ -6,6 +6,7 @@ import RichText from '@components/RichText/index.astro';
 import Player from '@components/Player';
 import Annotations from './AnnotationUI/Annotations/index.astro';
 import AnnotationHeader from './AnnotationUI/AnnotationHeader.astro';
+import { randomUUID } from 'crypto';
 
 interface Props extends SlateEventNodeProps {
   annotationSets: CollectionEntry<'annotations'>[];
@@ -26,7 +27,7 @@ const {
   embed,
 } = Astro.props;
 
-const avFileUuid = file || Object.keys(event.data.audiovisual_files)[0];
+const playerId = randomUUID();
 ---
 
 <div>
@@ -48,14 +49,14 @@ const avFileUuid = file || Object.keys(event.data.audiovisual_files)[0];
             return (
               <div
                 class='mediaContainer gap-4 flex flex-col'
-                data-player-id={file}
+                data-player-id={playerId}
                 data-player-url={url}
               >
                 {includes.includes('media') && (
                   <Container>
                     <Player
                       url={url}
-                      id={file}
+                      id={playerId}
                       client:only='react'
                       type={event.data.item_type}
                       start={start}
@@ -69,7 +70,7 @@ const avFileUuid = file || Object.keys(event.data.audiovisual_files)[0];
       }
       <Container>
         <AnnotationHeader
-          playerId={avFileUuid}
+          playerId={playerId}
           annotationSets={annotationSets}
           type={event.data.item_type}
         />
@@ -79,7 +80,7 @@ const avFileUuid = file || Object.keys(event.data.audiovisual_files)[0];
   <Container>
     <Annotations
       annotationSets={annotationSets}
-      playerId={avFileUuid}
+      playerId={playerId}
       type={event.data.item_type}
     />
   </Container>

--- a/src/components/EventViewer/AudioEvent.astro
+++ b/src/components/EventViewer/AudioEvent.astro
@@ -1,12 +1,11 @@
 ---
 import type { SlateEventNodeProps } from '@ty/slate';
 import type { CollectionEntry } from 'astro:content';
-import Container from '@components/Container.astro';
 import RichText from '@components/RichText/index.astro';
 import Player from '@components/Player';
 import Annotations from './AnnotationUI/Annotations/index.astro';
 import AnnotationHeader from './AnnotationUI/AnnotationHeader.astro';
-import { randomUUID } from 'crypto';
+import ConditionalContainer from './ConditionalContainer.astro';
 
 interface Props extends SlateEventNodeProps {
   annotationSets: CollectionEntry<'annotations'>[];
@@ -14,6 +13,7 @@ interface Props extends SlateEventNodeProps {
   // UUID of the audiovisual file, for embedded events
   file?: string;
   embed?: boolean;
+  playerId: string;
 }
 
 const {
@@ -25,22 +25,23 @@ const {
   file,
   annotationSets,
   embed,
+  playerId,
 } = Astro.props;
-
-const playerId = randomUUID();
 ---
 
 <div>
-  <div class={`sticky top-[80px] z-10 ${!embed ? 'shadow' : ''}`}>
+  <div
+    class={`sticky ${includes.includes('label') ? 'top-[80px]' : 'top-0'} z-10 ${!embed ? 'shadow' : ''}`}
+  >
     <div class='flex flex-col gap-6 bg-gray-100 py-6'>
-      <Container>
+      <ConditionalContainer condition={!embed}>
         {includes.includes('label') && <h1>{event.data.label}</h1>}
         {
           includes.includes('description') && event.data.description && (
             <RichText nodes={event.data.description} />
           )
         }
-      </Container>
+      </ConditionalContainer>
       {
         (includes.includes('annotations') || includes.includes('media')) &&
           Object.keys(event.data.audiovisual_files).map((file: string) => {
@@ -53,7 +54,7 @@ const playerId = randomUUID();
                 data-player-url={url}
               >
                 {includes.includes('media') && (
-                  <Container>
+                  <ConditionalContainer condition={!embed}>
                     <Player
                       url={url}
                       id={playerId}
@@ -62,26 +63,26 @@ const playerId = randomUUID();
                       start={start}
                       end={end}
                     />
-                  </Container>
+                  </ConditionalContainer>
                 )}
               </div>
             );
           })
       }
-      <Container>
+      <ConditionalContainer condition={!embed}>
         <AnnotationHeader
           playerId={playerId}
           annotationSets={annotationSets}
           type={event.data.item_type}
         />
-      </Container>
+      </ConditionalContainer>
     </div>
   </div>
-  <Container>
+  <ConditionalContainer condition={!embed}>
     <Annotations
       annotationSets={annotationSets}
       playerId={playerId}
       type={event.data.item_type}
     />
-  </Container>
+  </ConditionalContainer>
 </div>

--- a/src/components/EventViewer/ConditionalContainer.astro
+++ b/src/components/EventViewer/ConditionalContainer.astro
@@ -6,14 +6,15 @@ import Container from '@components/Container.astro';
 
 interface Props {
   condition?: boolean;
+  className?: string;
 }
 
-const { condition } = Astro.props;
+const { className, condition } = Astro.props;
 ---
 
 {
   condition ? (
-    <Container>
+    <Container className={className}>
       <slot />
     </Container>
   ) : (

--- a/src/components/EventViewer/ConditionalContainer.astro
+++ b/src/components/EventViewer/ConditionalContainer.astro
@@ -1,0 +1,22 @@
+---
+import Container from '@components/Container.astro';
+
+// What if we want to put something in a container, but only when
+// a certain condition is satisfied? That's a job for ConditionaContainer!
+
+interface Props {
+  condition?: boolean;
+}
+
+const { condition } = Astro.props;
+---
+
+{
+  condition ? (
+    <Container>
+      <slot />
+    </Container>
+  ) : (
+    <slot />
+  )
+}

--- a/src/components/EventViewer/VideoEvent.astro
+++ b/src/components/EventViewer/VideoEvent.astro
@@ -6,6 +6,7 @@ import RichText from '../RichText/index.astro';
 import Player from '@components/Player';
 import Annotations from './AnnotationUI/Annotations/index.astro';
 import AnnotationHeader from './AnnotationUI/AnnotationHeader.astro';
+import { randomUUID } from 'crypto';
 
 export interface Props {
   event: CollectionEntry<'events'>;
@@ -29,7 +30,7 @@ const {
   file,
 } = Astro.props;
 
-const avFileUuid = file || Object.keys(event.data.audiovisual_files)[0];
+const playerId = randomUUID();
 ---
 
 <Container className='flex flex-col gap-6 bg-gray-100 py-6'>
@@ -40,7 +41,7 @@ const avFileUuid = file || Object.keys(event.data.audiovisual_files)[0];
         return (
           <div
             class={`mediaContainer gap-4 ${sticky ? 'sticky top-0' : ''} ${event.data.item_type === 'Audio' ? 'flex flex-col' : 'grid grid-cols-[2fr,1fr] lg:gap-x-4'}`}
-            data-player-id={file}
+            data-player-id={playerId}
             data-player-url={url}
           >
             {includes.includes('media') && (
@@ -50,7 +51,7 @@ const avFileUuid = file || Object.keys(event.data.audiovisual_files)[0];
                 )}
                 <Player
                   url={url}
-                  id={file}
+                  id={playerId}
                   client:only='react'
                   type={event.data.item_type}
                   start={start}
@@ -72,12 +73,12 @@ const avFileUuid = file || Object.keys(event.data.audiovisual_files)[0];
             {includes.includes('annotations') && (
               <div class='py-4'>
                 <AnnotationHeader
-                  playerId={file}
+                  playerId={playerId}
                   annotationSets={annotationSets}
                   type={event.data.item_type}
                 />
                 <Annotations
-                  playerId={file}
+                  playerId={playerId}
                   annotationSets={annotationSets}
                   type={event.data.item_type}
                 />

--- a/src/components/EventViewer/VideoEvent.astro
+++ b/src/components/EventViewer/VideoEvent.astro
@@ -6,6 +6,7 @@ import RichText from '../RichText/index.astro';
 import Player from '@components/Player';
 import Annotations from './AnnotationUI/Annotations/index.astro';
 import AnnotationHeader from './AnnotationUI/AnnotationHeader.astro';
+import ConditionalContainer from './ConditionalContainer.astro';
 
 export interface Props {
   event: CollectionEntry<'events'>;
@@ -13,8 +14,8 @@ export interface Props {
   sticky?: boolean;
   end?: number;
   start?: number;
-  includes?: Includes[];
-  file?: string;
+  includes: Includes[];
+  file: string;
   isEmbed?: boolean;
   playerId: string;
 }
@@ -23,7 +24,7 @@ const {
   annotationSets,
   event,
   // include everything by default
-  includes = ['media', 'annotations', 'label', 'description'],
+  includes,
   start,
   end,
   sticky,
@@ -31,62 +32,63 @@ const {
   playerId,
   isEmbed,
 } = Astro.props;
+
+const url = event.data.audiovisual_files[file].file_url;
 ---
 
-<Container className='flex flex-col gap-6 bg-gray-100 py-6'>
+<ConditionalContainer
+  condition={!isEmbed}
+  className='flex flex-col gap-6 bg-gray-100 py-6'
+>
   {
-    (includes.includes('annotations') || includes.includes('media')) &&
-      Object.keys(event.data.audiovisual_files).map((file: string) => {
-        const url = event.data.audiovisual_files[file].file_url;
-        return (
-          <div
-            class={`mediaContainer gap-4 ${sticky ? 'sticky top-0' : ''} ${event.data.item_type === 'Audio' ? 'flex flex-col' : 'grid grid-cols-[2fr,1fr] lg:gap-x-4'}`}
-            data-player-id={playerId}
-            data-player-url={url}
-          >
-            {includes.includes('media') && (
-              <div>
-                {includes.includes('label') && (
-                  <h1 class='py-4'>{event.data.label}</h1>
-                )}
-                <Player
-                  url={url}
-                  id={playerId}
-                  client:only='react'
-                  type={event.data.item_type}
-                  start={start}
-                  end={end}
-                />
-                {includes.includes('description') && event.data.description && (
-                  <div class='my-4'>
-                    <RichText nodes={event.data.description} />
-                  </div>
-                )}
-                <div class='h-1 border-t border-gray-200 w-full' />
-                {event.data.citation && (
-                  <Container>
-                    <p>{event.data.citation}</p>
-                  </Container>
-                )}
+    (includes.includes('annotations') || includes.includes('media')) && (
+      <div
+        class={`mediaContainer gap-4 ${sticky ? 'sticky top-0' : ''} ${event.data.item_type === 'Audio' ? 'flex flex-col' : 'grid grid-cols-[2fr,1fr] lg:gap-x-4'}`}
+        data-player-id={playerId}
+        data-player-url={url}
+      >
+        {includes.includes('media') && (
+          <div>
+            {includes.includes('label') && (
+              <h1 class='py-4'>{event.data.label}</h1>
+            )}
+            <Player
+              url={url}
+              id={playerId}
+              client:only='react'
+              type={event.data.item_type}
+              start={start}
+              end={end}
+            />
+            {includes.includes('description') && event.data.description && (
+              <div class='my-4'>
+                <RichText nodes={event.data.description} />
               </div>
             )}
-            {includes.includes('annotations') && (
-              <div class='py-4'>
-                <AnnotationHeader
-                  playerId={playerId}
-                  annotationSets={annotationSets}
-                  type={event.data.item_type}
-                />
-                <Annotations
-                  playerId={playerId}
-                  annotationSets={annotationSets}
-                  isEmbed={isEmbed}
-                  type={event.data.item_type}
-                />
-              </div>
+            <div class='h-1 border-t border-gray-200 w-full' />
+            {event.data.citation && (
+              <Container>
+                <p>{event.data.citation}</p>
+              </Container>
             )}
           </div>
-        );
-      })
+        )}
+        {includes.includes('annotations') && (
+          <div class='py-4'>
+            <AnnotationHeader
+              playerId={playerId}
+              annotationSets={annotationSets}
+              type={event.data.item_type}
+            />
+            <Annotations
+              playerId={playerId}
+              annotationSets={annotationSets}
+              isEmbed={isEmbed}
+              type={event.data.item_type}
+            />
+          </div>
+        )}
+      </div>
+    )
   }
-</Container>
+</ConditionalContainer>

--- a/src/components/EventViewer/VideoEvent.astro
+++ b/src/components/EventViewer/VideoEvent.astro
@@ -15,7 +15,7 @@ export interface Props {
   start?: number;
   includes?: Includes[];
   file?: string;
-  embed?: boolean;
+  isEmbed?: boolean;
   playerId: string;
 }
 
@@ -29,6 +29,7 @@ const {
   sticky,
   file,
   playerId,
+  isEmbed,
 } = Astro.props;
 ---
 
@@ -79,6 +80,7 @@ const {
                 <Annotations
                   playerId={playerId}
                   annotationSets={annotationSets}
+                  isEmbed={isEmbed}
                   type={event.data.item_type}
                 />
               </div>

--- a/src/components/EventViewer/VideoEvent.astro
+++ b/src/components/EventViewer/VideoEvent.astro
@@ -53,6 +53,8 @@ const avFileUuid = file || Object.keys(event.data.audiovisual_files)[0];
                   id={file}
                   client:only='react'
                   type={event.data.item_type}
+                  start={start}
+                  end={end}
                 />
                 {includes.includes('description') && event.data.description && (
                   <div class='my-4'>

--- a/src/components/EventViewer/VideoEvent.astro
+++ b/src/components/EventViewer/VideoEvent.astro
@@ -6,7 +6,6 @@ import RichText from '../RichText/index.astro';
 import Player from '@components/Player';
 import Annotations from './AnnotationUI/Annotations/index.astro';
 import AnnotationHeader from './AnnotationUI/AnnotationHeader.astro';
-import { randomUUID } from 'crypto';
 
 export interface Props {
   event: CollectionEntry<'events'>;
@@ -17,6 +16,7 @@ export interface Props {
   includes?: Includes[];
   file?: string;
   embed?: boolean;
+  playerId: string;
 }
 
 const {
@@ -28,9 +28,8 @@ const {
   end,
   sticky,
   file,
+  playerId,
 } = Astro.props;
-
-const playerId = randomUUID();
 ---
 
 <Container className='flex flex-col gap-6 bg-gray-100 py-6'>

--- a/src/components/EventViewer/index.astro
+++ b/src/components/EventViewer/index.astro
@@ -3,16 +3,14 @@ import { getCollection } from 'astro:content';
 import type { SlateEventNodeProps } from '@ty/slate';
 import AudioEvent from './AudioEvent.astro';
 import VideoEvent from './VideoEvent.astro';
-import { randomUUID } from 'crypto';
 
 export interface Props extends Omit<SlateEventNodeProps, 'uuid'> {
   end?: number;
   start?: number;
   sticky?: boolean;
   uuids: string | string[];
-  embed?: boolean;
-  // player ID needs to be set in RichTextElement for embeds
-  playerId?: string;
+  isEmbed?: boolean;
+  playerId: string;
 }
 
 const {
@@ -22,7 +20,7 @@ const {
   start,
   end,
   sticky,
-  embed,
+  isEmbed,
   playerId,
 } = Astro.props;
 
@@ -45,7 +43,6 @@ const annotationData = await getCollection('annotations');
           <AudioEvent
             annotationSets={annotationSets}
             event={event}
-            playerId={playerId || randomUUID()}
             {...Astro.props}
           />
         )}
@@ -53,7 +50,6 @@ const annotationData = await getCollection('annotations');
           <VideoEvent
             annotationSets={annotationSets}
             event={event}
-            playerId={playerId || randomUUID()}
             {...Astro.props}
           />
         )}

--- a/src/components/EventViewer/index.astro
+++ b/src/components/EventViewer/index.astro
@@ -1,59 +1,68 @@
 ---
 import { getCollection } from 'astro:content';
-import type { SlateEventNodeProps } from '@ty/slate';
+import type { Includes, SlateEventNodeProps } from '@ty/slate';
 import AudioEvent from './AudioEvent.astro';
 import VideoEvent from './VideoEvent.astro';
+import { getEntry } from 'astro:content';
 
-export interface Props extends Omit<SlateEventNodeProps, 'uuid'> {
+export interface Props extends Omit<SlateEventNodeProps, 'uuid' | 'includes'> {
   end?: number;
   start?: number;
   sticky?: boolean;
-  uuids: string | string[];
+  uuid: string;
   isEmbed?: boolean;
   playerId: string;
+  file?: string;
+  includes?: Includes[];
 }
 
-const {
-  uuids,
-  // include everything by default
-  includes = ['media', 'annotations', 'label', 'description'],
-  start,
-  end,
-  sticky,
-  isEmbed,
-  playerId,
-} = Astro.props;
+const { file, uuid } = Astro.props;
 
-const associatedEvents = await getCollection('events', (ev) =>
-  Array.isArray(uuids) ? uuids.includes(ev.id) : ev.id === uuids
-);
+const event = await getEntry('events', uuid);
+
+if (!event) {
+  return null;
+}
 
 const annotationData = await getCollection('annotations');
+
+const annotationSets = annotationData.filter(
+  (an) => an.data.event_id === event.id
+);
+
+// allow a default file to be configured via props
+// otherwise, use the first file in the list
+const defaultFile = file || Object.keys(event.data.audiovisual_files)[0];
+
+const childProps = {
+  ...Astro.props,
+  includes: Astro.props.includes || [
+    'media',
+    'annotations',
+    'label',
+    'description',
+  ],
+  file: defaultFile,
+};
 ---
 
 {
-  associatedEvents.map((event) => {
-    const annotationSets = annotationData.filter(
-      (an) => an.data.event_id === event.id
-    );
-
-    return (
-      <div>
-        {event.data.item_type === 'Audio' && (
-          <AudioEvent
-            annotationSets={annotationSets}
-            event={event}
-            {...Astro.props}
-          />
-        )}
-        {event.data.item_type === 'Video' && (
-          <VideoEvent
-            annotationSets={annotationSets}
-            event={event}
-            {...Astro.props}
-          />
-        )}
-      </div>
-    );
-  })
+  (
+    <div>
+      {event.data.item_type === 'Audio' && (
+        <AudioEvent
+          annotationSets={annotationSets}
+          event={event}
+          {...childProps}
+        />
+      )}
+      {event.data.item_type === 'Video' && (
+        <VideoEvent
+          annotationSets={annotationSets}
+          event={event}
+          {...childProps}
+        />
+      )}
+    </div>
+  )
 }

--- a/src/components/EventViewer/index.astro
+++ b/src/components/EventViewer/index.astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content';
 import type { SlateEventNodeProps } from '@ty/slate';
 import AudioEvent from './AudioEvent.astro';
 import VideoEvent from './VideoEvent.astro';
+import { randomUUID } from 'crypto';
 
 export interface Props extends Omit<SlateEventNodeProps, 'uuid'> {
   end?: number;
@@ -10,6 +11,8 @@ export interface Props extends Omit<SlateEventNodeProps, 'uuid'> {
   sticky?: boolean;
   uuids: string | string[];
   embed?: boolean;
+  // player ID needs to be set in RichTextElement for embeds
+  playerId?: string;
 }
 
 const {
@@ -20,6 +23,7 @@ const {
   end,
   sticky,
   embed,
+  playerId,
 } = Astro.props;
 
 const associatedEvents = await getCollection('events', (ev) =>
@@ -41,6 +45,7 @@ const annotationData = await getCollection('annotations');
           <AudioEvent
             annotationSets={annotationSets}
             event={event}
+            playerId={playerId || randomUUID()}
             {...Astro.props}
           />
         )}
@@ -48,6 +53,7 @@ const annotationData = await getCollection('annotations');
           <VideoEvent
             annotationSets={annotationSets}
             event={event}
+            playerId={playerId || randomUUID()}
             {...Astro.props}
           />
         )}

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -78,7 +78,7 @@ const Player: React.FC<Props> = (props) => {
         player.current.seekTo(val[0] * duration);
       }
     },
-    [player, setSeeking]
+    [player, setSeeking, duration]
   );
 
   // whether a given timestamp has a corresponding annotation

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -16,11 +16,11 @@ import { useStore } from '@nanostores/react';
 import { formatTimestamp } from '../../utils/player.ts';
 
 interface Props {
-  url: string;
-  // optional props for controlling the
-  // player from a parent component
+  end?: number;
   id: string;
+  start?: number;
   type: 'Audio' | 'Video';
+  url: string;
 }
 
 const getSegments = (playerState: AnnotationState): [number, number][] => {
@@ -161,7 +161,7 @@ const Player: React.FC<Props> = (props) => {
           }
         }}
         onReady={(player) => setPlayer(player)}
-        progressInterval={50}
+        progressInterval={500}
         url={props.url}
         height={props.type === 'Video' ? '100%' : 0}
         width={props.type === 'Video' ? '100%' : 0}

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -119,7 +119,14 @@ const Player: React.FC<Props> = (props) => {
   const onProgress = (data: OnProgressProps) => {
     // don't move the point if the user is currently dragging it
     if (!seeking) {
-      if (
+      // stop playing if we've reached the end of a clip
+      if (props.end && data.playedSeconds >= props.end) {
+        $pagePlayersState.setKey(props.id, {
+          ...playerState,
+          isPlaying: false,
+          position: data.playedSeconds,
+        });
+      } else if (
         playerState.snapToAnnotations &&
         !isContainedInSegment(segments, data.playedSeconds)
       ) {
@@ -157,7 +164,6 @@ const Player: React.FC<Props> = (props) => {
       <ReactPlayer
         controls={props.type === 'Video'}
         playing={playerState.isPlaying}
-        played={playerState.position / duration || 0}
         muted={muted}
         onDuration={(dur) => {
           if (props.start && props.end) {
@@ -171,7 +177,7 @@ const Player: React.FC<Props> = (props) => {
           }
         }}
         onProgress={onProgress}
-        progressInterval={500}
+        progressInterval={250}
         ref={player}
         url={props.url}
         height={props.type === 'Video' ? '100%' : 0}

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -14,7 +14,6 @@ import { $pagePlayersState, type AnnotationState } from '../../store.ts';
 import { useStore } from '@nanostores/react';
 import { formatTimestamp } from '../../utils/player.ts';
 import type { OnProgressProps } from 'react-player/base';
-import type FilePlayer from 'react-player/file';
 
 interface Props {
   end?: number;

--- a/src/components/Player/types.ts
+++ b/src/components/Player/types.ts
@@ -1,0 +1,4 @@
+// types that are used by react-player, which
+// annoyingly doesn't include its own types
+
+export interface ProgressData {}

--- a/src/components/Player/types.ts
+++ b/src/components/Player/types.ts
@@ -1,4 +1,0 @@
-// types that are used by react-player, which
-// annoyingly doesn't include its own types
-
-export interface ProgressData {}

--- a/src/components/RichText/RichTextElement.astro
+++ b/src/components/RichText/RichTextElement.astro
@@ -98,16 +98,17 @@ const getImageClass = (size: 'thumbnail' | 'medium' | 'large' | 'full') => {
 
         return (
           <div
-            class='bg-gray-100 px-4 pb-4 max-h-[600px] overflow-y-auto eventContainer'
+            class='bg-gray-100 p-4 max-h-[700px] overflow-y-auto eventContainer'
             data-player-id={playerId}
           >
             <EventViewer
               end={element.end}
               start={element.start}
               includes={element.includes}
-              uuids={element.uuid}
+              uuid={element.uuid}
               isEmbed
               playerId={playerId}
+              file={element.file}
             />
           </div>
         );

--- a/src/components/RichText/RichTextElement.astro
+++ b/src/components/RichText/RichTextElement.astro
@@ -1,6 +1,7 @@
 ---
 import EventViewer from '@components/EventViewer/index.astro';
 import TableOfContents from '@components/TableOfContents.astro';
+import { randomUUID } from 'crypto';
 
 const { attributes, element } = Astro.props;
 
@@ -93,14 +94,20 @@ const getImageClass = (size: 'thumbnail' | 'medium' | 'large' | 'full') => {
           </div>
         );
       case 'event':
+        const playerId = randomUUID();
+
         return (
-          <div class='bg-gray-100 p-4'>
+          <div
+            class='bg-gray-100 px-4 pb-4 max-h-[600px] overflow-y-auto eventContainer'
+            data-player-id={playerId}
+          >
             <EventViewer
               end={element.end}
               start={element.start}
               includes={element.includes}
               uuids={element.uuid}
               embed
+              playerId={playerId}
             />
           </div>
         );

--- a/src/components/RichText/RichTextElement.astro
+++ b/src/components/RichText/RichTextElement.astro
@@ -106,7 +106,7 @@ const getImageClass = (size: 'thumbnail' | 'medium' | 'large' | 'full') => {
               start={element.start}
               includes={element.includes}
               uuids={element.uuid}
-              embed
+              isEmbed
               playerId={playerId}
             />
           </div>

--- a/src/components/RichText/RichTextElement.astro
+++ b/src/components/RichText/RichTextElement.astro
@@ -98,7 +98,7 @@ const getImageClass = (size: 'thumbnail' | 'medium' | 'large' | 'full') => {
 
         return (
           <div
-            class='bg-gray-100 p-4 max-h-[700px] overflow-y-auto eventContainer'
+            class='bg-gray-100 px-4 pb-4 max-h-[700px] overflow-y-auto eventContainer'
             data-player-id={playerId}
           >
             <EventViewer

--- a/src/pages/events/[pageUuid].astro
+++ b/src/pages/events/[pageUuid].astro
@@ -35,10 +35,14 @@ if (!page.data.autogenerate.type_id) {
 }
 
 const playerId = randomUUID();
+
+const eventUuids = Array.isArray(page.data.autogenerate.type_id)
+  ? page.data.autogenerate.type_id
+  : [page.data.autogenerate.type_id];
 ---
 
 <Layout title={page.data.title} background='gray-100'>
   <div class='eventContainer' data-player-id={playerId}>
-    <EventViewer playerId={playerId} uuids={page.data.autogenerate.type_id} />
+    {eventUuids.map((uuid) => <EventViewer playerId={playerId} uuid={uuid} />)}
   </div>
 </Layout>

--- a/src/pages/events/[pageUuid].astro
+++ b/src/pages/events/[pageUuid].astro
@@ -5,6 +5,7 @@ import Layout from '@layouts/Layout.astro';
 import { getEntry } from 'astro:content';
 import EventViewer from '@components/EventViewer/index.astro';
 import { getPage, getPages } from 'src/utils/pages';
+import { randomUUID } from 'crypto';
 
 const projectData = await getEntry('project', 'project');
 
@@ -32,10 +33,12 @@ const page = await getPage(pageUuid);
 if (!page.data.autogenerate.type_id) {
   return Astro.redirect(`/${baseUrl}`);
 }
+
+const playerId = randomUUID();
 ---
 
 <Layout title={page.data.title} background='gray-100'>
-  <div class='eventContainer'>
-    <EventViewer uuids={page.data.autogenerate.type_id} />
+  <div class='eventContainer' data-player-id={playerId}>
+    <EventViewer playerId={playerId} uuids={page.data.autogenerate.type_id} />
   </div>
 </Layout>

--- a/src/pages/events/[pageUuid].astro
+++ b/src/pages/events/[pageUuid].astro
@@ -35,5 +35,7 @@ if (!page.data.autogenerate.type_id) {
 ---
 
 <Layout title={page.data.title} background='gray-100'>
-  <EventViewer uuids={page.data.autogenerate.type_id} />
+  <div class='eventContainer'>
+    <EventViewer uuids={page.data.autogenerate.type_id} />
+  </div>
 </Layout>

--- a/src/pages/pages/[pageUuid].astro
+++ b/src/pages/pages/[pageUuid].astro
@@ -3,7 +3,6 @@ import type { GetStaticPaths } from 'astro';
 import { dynamicConfig } from 'dynamic-astro-config';
 import Layout from '@layouts/Layout.astro';
 import Container from '@components/Container.astro';
-import { getCollection } from 'astro:content';
 import { getEntry } from 'astro:content';
 import RichText from '../../components/RichText/index.astro';
 import { getPage, getPages } from 'src/utils/pages';

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,5 @@
 import type { DisplayedAnnotation, Tag } from '@ty/index.ts';
-import { computed, deepMap } from 'nanostores';
+import { deepMap } from 'nanostores';
 import { Node } from 'slate';
 
 export interface AnnotationState {
@@ -18,6 +18,11 @@ export interface AnnotationState {
   annotations: DisplayedAnnotation[];
   filteredAnnotations: string[];
   snapToAnnotations: boolean;
+  clip?: {
+    start: number;
+    end: number;
+  };
+  isEmbed?: boolean;
 }
 
 // keeps track of all players on the loaded page
@@ -56,6 +61,22 @@ const getFilteredAnnotations = (newState: AnnotationState) =>
         }
 
         if (!match) {
+          return false;
+        }
+      }
+
+      // hide if it's not in the selected clip
+      if (newState.clip) {
+        // should show if any part of the annotation overlaps with the selected clip,
+        // even if it's partly outside the clip
+        const startTimeMatch =
+          ann.start_time >= newState.clip.start &&
+          ann.start_time <= newState.clip.end;
+        const endTimeMatch =
+          ann.end_time >= newState.clip.start &&
+          ann.end_time <= newState.clip.end;
+
+        if (!startTimeMatch && !endTimeMatch) {
           return false;
         }
       }
@@ -194,6 +215,19 @@ export const toggleSetFilter = (set: string, playerId: string) => {
   $pagePlayersState.setKey(playerId, newState);
 };
 
+export const setSearchFilter = (searchQuery: string, playerId: string) => {
+  const oldState = $pagePlayersState.get()[playerId];
+
+  const newState = {
+    ...oldState,
+    searchQuery,
+  };
+
+  newState.filteredAnnotations = getFilteredAnnotations(newState);
+
+  $pagePlayersState.setKey(playerId, newState);
+};
+
 export const clearFilter = (type: 'sets' | 'tags', playerId: string) => {
   const oldState = $pagePlayersState.get()[playerId];
 
@@ -207,6 +241,19 @@ export const clearFilter = (type: 'sets' | 'tags', playerId: string) => {
   if (type === 'tags') {
     newState.snapToAnnotations = false;
   }
+
+  $pagePlayersState.setKey(playerId, newState);
+};
+
+export const setClip = (
+  clip: { start: number; end: number },
+  playerId: string
+) => {
+  const oldState = $pagePlayersState.get()[playerId];
+
+  const newState = { ...oldState, clip };
+
+  newState.filteredAnnotations = getFilteredAnnotations(newState);
 
   $pagePlayersState.setKey(playerId, newState);
 };

--- a/src/types/slate.ts
+++ b/src/types/slate.ts
@@ -8,9 +8,10 @@ export interface SlateEventNodeData {
   uuid: string;
 }
 
-export interface SlateEventNodeProps extends Omit<SlateEventNodeData, 'file' | 'includes' | 'uuid'> {
+export interface SlateEventNodeProps
+  extends Omit<SlateEventNodeData, 'file' | 'includes' | 'uuid'> {
   file?: string;
-  includes?: Includes[]
+  includes: Includes[];
 }
 
 export interface SlateCompareEventData {


### PR DESCRIPTION
# Summary

This PR, originally intended to be a small feature update to enable clip embeds, ended up being a bit of an adventure with all the refactoring/restructuring I had to do to in order to actually get the clip feature done.

* tons of fixes for embedded events
  * the autoscroll feature now scrolls within its container when inside an event, instead of scrolling the entire page
  * styling fixes for both audio and video embeds
* increased the `progressInterval` of the player from 50ms to 250ms (we needed more frequent updates on the admin client because we show millisecond-level timestamps there) and removed the check in the clientside `Annotations` component code that rate limited the state listener (no longer needed with significantly less frequent state updates)
* updated `react-player` to their canary release, which fixes the TypeScript issues caused by bad packaging and doesn't include many other changes
* added a new `ConditionalContainer` component that wraps its content in a `Container` only if a provided `condition` is true (this helps with embeds)
* use randomly generated UUIDs to track the different players' states instead of AV file UUIDs (which may be repeated if multiple clips are embedded on a page)
* fixed text searches, which weren't correctly set up with the new state functions
* updated the way `file` and `includes` props are passed through the event viewer component hierarchy to make the flow a little clearer prevent the need to redefine defaults multiple times
* adds start/end support to the player component
  * updates the clientside annotation code to hide annotations that fall entirely outside of a clip (i.e. if the clip is 1:00-2:00 and an annotation is 1:55-2:30, the annotation will still be shown because it overlaps slightly)