### PR TITLE
Indent child pages in Table of Contents

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -9,6 +9,18 @@ interface SidebarProps {
   pageUuid?: string;
 }
 
+const getHref = (page: PageCollectionEntry, baseUrl: string) => {
+  if (page.data.autogenerate.type === 'home') {
+    return `/${baseUrl}`;
+  }
+
+  if (page.data.autogenerate.enabled) {
+    return `/${baseUrl}/events/${page.id}`;
+  }
+
+  return `/${baseUrl}/pages/${page.id}`;
+};
+
 const Sidebar: React.FC<SidebarProps> = (props) => {
   const [show, setShow] = useState(false);
 
@@ -43,9 +55,7 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
             </button>
           </div>
           {props.pages.map((page) => (
-            <a
-              href={`/${props.baseUrl}/${page.data.autogenerate.enabled ? 'events' : 'pages'}/${page.id}`}
-            >
+            <a href={getHref(page, props.baseUrl)} key={page.id}>
               <div className='p-4 hover:bg-blue-hover'>
                 <p
                   key={page.id}

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,7 +1,7 @@
 ---
 import { getEntry } from 'astro:content';
 import { dynamicConfig } from 'dynamic-astro-config';
-import { getOrder, getPages } from 'src/utils/pages';
+import { getPages } from 'src/utils/pages';
 
 const projectData = await getEntry('project', 'project');
 
@@ -10,18 +10,27 @@ const baseUrl = import.meta.env.PROD
   : dynamicConfig.base;
 
 const pages = await getPages();
+
+const homePage = pages.find((p) => p.data.autogenerate.type === 'home');
+
+if (!homePage) {
+  throw new Error('No homepage found?!?');
+}
 ---
 
 <div class='py-4 flex flex-col gap-2'>
+  <a class='underline' href={baseUrl}>
+    {homePage.data.title}
+  </a>
   {
     pages
-      .filter((page) => page.data.autogenerate.type !== 'home')
+      .filter((page) => page.id !== homePage.id)
       .map((page) => (
         <a
-          class='underline'
+          class={`underline ${page.data.parent ? 'ml-4' : ''}`}
           href={`/${baseUrl}/${page.data.autogenerate.enabled ? 'events' : 'pages'}/${page.id}`}
         >
-          {page.data.title}
+          <p>{page.data.title}</p>
         </a>
       ))
   }


### PR DESCRIPTION
# Summary

* adds indentation to child pages in the `TableOfContents` component
* fixes bad linking logic for the homepage where it was being treated like an event (I'm not sure how it was able to work before?)

## Screenshot
<img width="625" alt="Screenshot 2024-10-10 at 3 23 17 PM" src="https://github.com/user-attachments/assets/cfc83cac-814e-4962-8b9b-3d9d37030327">

