### PR TITLE
Slugify paths

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -32,7 +32,10 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
   // highlight the current page
   // if there's no page slug, that means we're on the homepage
   const isSelected = (page: PageCollectionEntry) => {
-    return page.id === (props.pageUuid || homeUuid || page.data.slug);
+    return (
+      page.id === (props.pageUuid || homeUuid) ||
+      props.pageUuid === page.data.slug
+    );
   };
 
   return (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -32,7 +32,7 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
   // highlight the current page
   // if there's no page slug, that means we're on the homepage
   const isSelected = (page: PageCollectionEntry) => {
-    return page.id === (props.pageUuid || homeUuid);
+    return page.id === (props.pageUuid || homeUuid || page.data.slug);
   };
 
   return (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -15,10 +15,10 @@ const getHref = (page: PageCollectionEntry, baseUrl: string) => {
   }
 
   if (page.data.autogenerate.enabled) {
-    return `/${baseUrl}/events/${page.id}`;
+    return `/${baseUrl}/events/${page.data.slug || page.id}`;
   }
 
-  return `/${baseUrl}/pages/${page.id}`;
+  return `/${baseUrl}/pages/${page.data.slug || page.id}`;
 };
 
 const Sidebar: React.FC<SidebarProps> = (props) => {
@@ -59,7 +59,9 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
               <div className='p-4 hover:bg-blue-hover'>
                 <p
                   key={page.id}
-                  className={`${isSelected(page) ? 'font-bold' : ''} ${page.data.parent ? 'ml-6' : ''}`}
+                  className={`${isSelected(page) ? 'font-bold' : ''} ${
+                    page.data.parent ? 'ml-6' : ''
+                  }`}
                   title={page.data.title}
                 >
                   {page.data.title}

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -16,12 +16,10 @@ const homePage = pages.find((p) => p.data.autogenerate.type === 'home');
 if (!homePage) {
   throw new Error('No homepage found?!?');
 }
-
-console.log('baseUrl: ', baseUrl);
 ---
 
 <div class='py-4 flex flex-col gap-2'>
-  <a class='underline' href={baseUrl}>
+  <a class='underline' href={'/'}>
     {homePage.data.title}
   </a>
   {

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -19,7 +19,7 @@ if (!homePage) {
 ---
 
 <div class='py-4 flex flex-col gap-2'>
-  <a class='underline' href={'/'}>
+  <a class='underline' href={`/${baseUrl}`}>
     {homePage.data.title}
   </a>
   {

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -24,7 +24,7 @@ if (!homePage) {
   </a>
   {
     pages
-      .filter((page) => page.id !== (homePage.data.slug || homePage.id))
+      .filter((page) => page.id !== homePage.id)
       .map((page) => (
         <a
           class={`underline ${page.data.parent ? 'ml-4' : ''}`}

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -24,7 +24,7 @@ if (!homePage) {
   </a>
   {
     pages
-      .filter((page) => page.id !== homePage.id)
+      .filter((page) => page.id !== (homePage.data.slug || homePage.id))
       .map((page) => (
         <a
           class={`underline ${page.data.parent ? 'ml-4' : ''}`}

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -16,6 +16,8 @@ const homePage = pages.find((p) => p.data.autogenerate.type === 'home');
 if (!homePage) {
   throw new Error('No homepage found?!?');
 }
+
+console.log('baseUrl: ', baseUrl);
 ---
 
 <div class='py-4 flex flex-col gap-2'>

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -28,7 +28,7 @@ if (!homePage) {
       .map((page) => (
         <a
           class={`underline ${page.data.parent ? 'ml-4' : ''}`}
-          href={`/${baseUrl}/${page.data.autogenerate.enabled ? 'events' : 'pages'}/${page.id}`}
+          href={`/${baseUrl}/${page.data.autogenerate.enabled ? 'events' : 'pages'}/${page.data.slug || page.id}`}
         >
           <p>{page.data.title}</p>
         </a>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -65,7 +65,7 @@ const pageCollection = defineCollection({
       parent: z.string().nullish(),
       updated_at: z.string(),
       updated_by: z.string(),
-      slug: z.string(),
+      slug: z.string().nullish(),
       autogenerate: z.object({
         enabled: z.boolean(),
         type: z.string(),

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -8,16 +8,20 @@ const annotationCollection = defineCollection({
     event_id: z.string(),
     source_id: z.string(),
     set: z.string(),
-    annotations: z.array(z.object({
-      uuid: z.string(),
-      start_time: z.number(),
-      end_time: z.number(),
-      annotation: slateNodeArray,
-      tags: z.array(z.object({
-        category: z.string(),
-        tag: z.string()
-      }))
-    }))
+    annotations: z.array(
+      z.object({
+        uuid: z.string(),
+        start_time: z.number(),
+        end_time: z.number(),
+        annotation: slateNodeArray,
+        tags: z.array(
+          z.object({
+            category: z.string(),
+            tag: z.string(),
+          })
+        ),
+      })
+    ),
   }),
 });
 
@@ -61,6 +65,7 @@ const pageCollection = defineCollection({
       parent: z.string().nullish(),
       updated_at: z.string(),
       updated_by: z.string(),
+      slug: z.string(),
       autogenerate: z.object({
         enabled: z.boolean(),
         type: z.string(),
@@ -84,32 +89,38 @@ const projectCollection = defineCollection({
       authors: z.string(),
       media_player: z.enum(['avannotate', 'universal', 'aviary']),
       auto_populate_home_page: z.boolean(),
-      additional_users: z.array(z.object({
-        login_name: z.string(),
-        avatar_url: z.string(),
-        admin: z.boolean(),
-        name: z.string().nullish(),
-      })),
+      additional_users: z.array(
+        z.object({
+          login_name: z.string(),
+          avatar_url: z.string(),
+          admin: z.boolean(),
+          name: z.string().nullish(),
+        })
+      ),
       tags: z.object({
-        tagGroups: z.array(z.object({
-          category: z.string(),
-          color: z.string()
-        })),
-        tags: z.array(z.object({
-          category: z.string(),
-          tag: z.string()
-        }))
+        tagGroups: z.array(
+          z.object({
+            category: z.string(),
+            color: z.string(),
+          })
+        ),
+        tags: z.array(
+          z.object({
+            category: z.string(),
+            tag: z.string(),
+          })
+        ),
       }),
       created_at: z.string(),
-      updated_at: z.string()
+      updated_at: z.string(),
     }),
     publish: z.object({
       publish_pages_app: z.boolean(),
       publish_sha: z.string(),
-      publish_iso_date: z.string()
+      publish_iso_date: z.string(),
     }),
     // not sure what goes in here
-    users: z.array(z.any())
+    users: z.array(z.any()),
   }),
 });
 

--- a/src/pages/events/[pageUuid].astro
+++ b/src/pages/events/[pageUuid].astro
@@ -18,7 +18,7 @@ export const getStaticPaths = (async () => {
   const pages = await getPages((page) => page.data.autogenerate.enabled);
 
   return pages.map((page) => ({
-    params: { pageUuid: page.id },
+    params: { pageUuid: page.data.slug || page.id },
   }));
 }) satisfies GetStaticPaths;
 

--- a/src/pages/pages/[pageUuid].astro
+++ b/src/pages/pages/[pageUuid].astro
@@ -17,7 +17,7 @@ export const getStaticPaths = (async () => {
   const eventPages = await getPages((p) => !p.data.autogenerate.enabled);
 
   return eventPages.map((page) => ({
-    params: { pageUuid: page.id },
+    params: { pageUuid: page.data.slug || page.id },
   }));
 }) satisfies GetStaticPaths;
 

--- a/src/utils/pages.ts
+++ b/src/utils/pages.ts
@@ -94,6 +94,7 @@ export const getPage = async (uuid: string) => {
     });
 
     // assume there is only one...
+    console.log('Results: ', results[0]);
     return results[0];
   }
 };

--- a/src/utils/pages.ts
+++ b/src/utils/pages.ts
@@ -95,7 +95,6 @@ export const getPage = async (uuid: string) => {
     });
 
     // assume there is only one...
-    console.log('Results: ', results[0]);
     return results[0] as PageCollectionEntry;
   }
 };

--- a/src/utils/pages.ts
+++ b/src/utils/pages.ts
@@ -25,13 +25,13 @@ export const getPages = async (
   const pageOrder = await getOrder();
 
   const results = await getCollection('pages', (page) => {
-    if (page.id === 'order') {
+    if ((page as PageCollectionEntry).id === 'order') {
       return false;
     }
 
     // skip pages that aren't mentioned in the order file
     // something has gone terribly wrong if this happens!
-    if (!pageOrder.data.includes(page.id)) {
+    if (!pageOrder.data.includes((page as PageCollectionEntry).id)) {
       return false;
     }
 
@@ -75,27 +75,24 @@ export const getPage = async (uuid: string) => {
   } else {
     // using slugs
     const pageOrder = await getOrder();
-    const results = await getCollection(
-      'pages',
-      (page: PageCollectionEntry) => {
-        if (page.id === 'order') {
-          return false;
-        }
-
-        // skip pages that aren't mentioned in the order file
-        // something has gone terribly wrong if this happens!
-        if (!pageOrder.data.includes(page.id)) {
-          return false;
-        }
-
-        // Look for the slug
-        if (page.data.slug === uuid) {
-          return true;
-        }
-
+    const results = await getCollection('pages', (page) => {
+      if ((page as PageCollectionEntry).id === 'order') {
         return false;
       }
-    );
+
+      // skip pages that aren't mentioned in the order file
+      // something has gone terribly wrong if this happens!
+      if (!pageOrder.data.includes((page as PageCollectionEntry).id)) {
+        return false;
+      }
+
+      // Look for the slug
+      if ((page as PageCollectionEntry).data.slug === uuid) {
+        return true;
+      }
+
+      return false;
+    });
 
     // assume there is only one...
     console.log('Results: ', results[0]);

--- a/src/utils/pages.ts
+++ b/src/utils/pages.ts
@@ -74,28 +74,32 @@ export const getPage = async (uuid: string) => {
     return (await getEntry('pages', uuid)) as PageCollectionEntry;
   } else {
     // using slugs
-    const results = await getCollection('pages', (page) => {
-      if (page.id === 'order') {
+    const pageOrder = await getOrder();
+    const results = await getCollection(
+      'pages',
+      (page: PageCollectionEntry) => {
+        if (page.id === 'order') {
+          return false;
+        }
+
+        // skip pages that aren't mentioned in the order file
+        // something has gone terribly wrong if this happens!
+        if (!pageOrder.data.includes(page.id)) {
+          return false;
+        }
+
+        // Look for the slug
+        if (page.data.slug === uuid) {
+          return true;
+        }
+
         return false;
       }
-
-      // skip pages that aren't mentioned in the order file
-      // something has gone terribly wrong if this happens!
-      if (!pageOrder.data.includes(page.id)) {
-        return false;
-      }
-
-      // Look for the slug
-      if (page.data.slug === uuid) {
-        return true;
-      }
-
-      return false;
-    });
+    );
 
     // assume there is only one...
     console.log('Results: ', results[0]);
-    return results[0];
+    return results[0] as PageCollectionEntry;
   }
 };
 


### PR DESCRIPTION
# Summary

This PR makes use of a previous [PR](https://github.com/AVAnnotate/admin-client/pull/150) on the admin-client which creates human readable slugs for Pages.  The client will use the slugs if the exist, otherwise it will continue using the UUIDs.