### PR TITLE
Fix project data path

### DIFF
--- a/dynamic-astro-config.js
+++ b/dynamic-astro-config.js
@@ -1,15 +1,23 @@
 import react from '@astrojs/react';
-import tailwind from "@astrojs/tailwind";
+import tailwind from '@astrojs/tailwind';
 
 // Please note that this file will be updated by the AVAnnotate Admin
 // application. No changes made here to the `site` or `base` fields will be reflected in the deployed
 // site.
 
-import project from '../data/project.json'
+import project from './src/content/project/project.json';
 
 export const dynamicConfig = {
   integrations: [react(), tailwind()],
-  site: import.meta.env.PROD ? `https://${project.project.github_org}.github.io/${project.project.slug}` : undefined,
+  site: import.meta.env.PROD
+    ? `https://${project.project.github_org}.github.io/${project.project.slug}`
+    : undefined,
   base: import.meta.env.PROD ? `${project.project.slug}` : 'dist',
-  srcDir: import.meta.env.PROD ? project.project.media_player === 'avannotate' ? './src' : project.project.media_player === 'aviary' ? './src-aviary' : './src' : './src'
-}
+  srcDir: import.meta.env.PROD
+    ? project.project.media_player === 'avannotate'
+      ? './src'
+      : project.project.media_player === 'aviary'
+      ? './src-aviary'
+      : './src'
+    : './src',
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,9 +42,6 @@
         "eslint": "^9.9.1",
         "tsx": "^4.16.2",
         "typescript": "^5.4.5"
-      },
-      "peerDependencies": {
-        "react": "^17.0.2"
       }
     },
     "node_modules/@alloc/quick-lru": {


### PR DESCRIPTION
# Summary

This PR reverts a recent change in the config that told Astro to look in `../data` instead of `src/content` for project data, restoring the `src/content` value. This doesn't make a difference for production deployments (the data exists in both places there) but avoids the need for extra config on local dev builds.

It also includes some autoformatting from Prettier and a change to my `package-lock` that came up when I ran `npm i`.