### PR TITLE
Video player fixes

### DIFF
--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -35,7 +35,7 @@ const sortedAnnotations = annotationSets
       annotations={sortedAnnotations}
       playerId={playerId}
       isEmbed={isEmbed}
-      client:only='react'
+      client:load
     />
     <div
       class={`${type === 'Video' ? 'overflow-y-scroll max-h-[510px] video videoAnnotationContainer' : ''}`}

--- a/src/components/EventViewer/AnnotationUI/TagFilter.tsx
+++ b/src/components/EventViewer/AnnotationUI/TagFilter.tsx
@@ -1,4 +1,4 @@
-import TagPill from '@components/Tags/TagPill.tsx';
+import TagPill from '@components/tags/TagPill.tsx';
 import {
   Checkbox,
   Popover,

--- a/src/components/EventViewer/AnnotationUI/TagFilter.tsx
+++ b/src/components/EventViewer/AnnotationUI/TagFilter.tsx
@@ -1,4 +1,4 @@
-import TagPill from '@components/tags/TagPill.tsx';
+import TagPill from '@components/Tags/TagPill.tsx';
 import {
   Checkbox,
   Popover,
@@ -93,7 +93,9 @@ const TagFilter = (props: TagFilterProps) => {
                 <p className='text-sm font-semibold'>Annotation Sets</p>
                 {thisPlayer.sets.length > 0 && (
                   <div className='bg-primary rounded-lg flex items-center justify-center gap-2 py-1 px-2 text-white cursor-default text-xs font-semibold'>
-                    <p>{`${thisPlayer.sets.length} filter${thisPlayer.sets.length > 1 ? 's' : ''} applied`}</p>
+                    <p>{`${thisPlayer.sets.length} filter${
+                      thisPlayer.sets.length > 1 ? 's' : ''
+                    } applied`}</p>
                     <XMarkIcon
                       className='size-4 text-white hover:scale-105 cursor-pointer'
                       onClick={() => clearFilter('sets', playerId)}
@@ -111,11 +113,11 @@ const TagFilter = (props: TagFilterProps) => {
                       onChange={() => {
                         toggleSetFilter(set.id, playerId);
                       }}
-                      className='group size-4 bg-white rounded-sm data-[checked]:bg-primary p-0.5 ring-1 ring-gray-300 ring-inset data-[checked]:ring-primary'
+                      className='min-w-4 group size-4 bg-white rounded-sm data-[checked]:bg-primary p-0.5 ring-1 ring-gray-300 ring-inset data-[checked]:ring-primary'
                     >
                       <CheckIcon className='hidden size-3 group-data-[checked]:block text-white' />
                     </Checkbox>
-                    <p className='capitalize font-semibold text-xs'>
+                    <p className='grow-0 capitalize font-semibold text-xs'>
                       {set.data.set.replaceAll('_', '')}
                     </p>
                   </div>
@@ -125,10 +127,12 @@ const TagFilter = (props: TagFilterProps) => {
           )}
         </div>
         <div className='flex flex-row justify-between w-full pb-2'>
-          <p className='text-sm  font-semibold'>Tags</p>
+          <p className='text-sm font-semibold'>Tags</p>
           {thisPlayer.tags.length > 0 && (
             <div className='bg-primary rounded-lg flex items-center justify-center gap-2 py-1 px-2 text-white cursor-default text-xs font-semibold'>
-              <p>{`${thisPlayer.tags.length} filter${thisPlayer.tags.length > 1 ? 's' : ''} applied`}</p>
+              <p>{`${thisPlayer.tags.length} filter${
+                thisPlayer.tags.length > 1 ? 's' : ''
+              } applied`}</p>
               <XMarkIcon
                 className='size-4 text-white hover:scale-105 cursor-pointer'
                 onClick={() => clearFilter('tags', playerId)}

--- a/src/components/RichText/index.astro
+++ b/src/components/RichText/index.astro
@@ -34,7 +34,11 @@ const { nodes } = Astro.props;
         }
       };
 
-      return nodes.map((node: Node) => serialize(node));
+      return (
+        <div class='[overflow-wrap:anywhere]'>
+          {nodes.map((node: Node) => serialize(node))}
+        </div>
+      );
     })()
   }
 </div>


### PR DESCRIPTION
# Summary

This PR fixes a couple bugs and might fix a third:

* adds a `min-width` to prevent annotation set checkboxes from getting squished horizontally when the set name is really long
* wraps rich text into a `div` and applies `overflow-wrap: anywhere`, which allows the browser to break long words (such as URLs) down the middle to wrap into a new line instead of overflowing, without treating normal-length words any differently. This seems to be the default behavior in Firefox, but Blink and WebKit browsers allow long links to extend the width of their containers by default. In the big picture, this fixes the issue where the annotations pane would sometimes get really wide despite the `2fr 1fr` grid style.
* changes the `AnnotationNanostorePopulator` from `client:only` to `client:load` so it loads sooner. I can't replicate https://github.com/AVAnnotate/project-client/issues/57 locally so I can't really test whether this solves the problem without a deployment, but it's the best solution if it does.