### PR TITLE
Fix sidebar current page detection logic

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,7 +8,7 @@ import { getPages } from 'src/utils/pages';
 const projectData = await getEntry('project', 'project');
 const pages = await getPages();
 
-const { pageSlug, eventSlug } = Astro.params;
+const { pageSlug } = Astro.params;
 
 const baseUrl = import.meta.env.PROD
   ? projectData.data.project.slug
@@ -17,12 +17,7 @@ const baseUrl = import.meta.env.PROD
 
 <div class='bg-secondary text-white w-full h-[80px] py-6 sticky top-0 z-20'>
   <Container className='flex flex-row items-center gap-[52px]'>
-    <Sidebar
-      baseUrl={baseUrl}
-      client:load
-      pages={pages}
-      slug={pageSlug || eventSlug}
-    />
+    <Sidebar baseUrl={baseUrl} client:load pages={pages} slug={pageSlug} />
     <a href={`/${baseUrl}`} class='text-lg'>{projectData.data.project.title}</a>
   </Container>
 </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -21,7 +21,7 @@ const baseUrl = import.meta.env.PROD
       baseUrl={baseUrl}
       client:load
       pages={pages}
-      pageSlug={pageSlug || eventSlug}
+      slug={pageSlug || eventSlug}
     />
     <a href={`/${baseUrl}`} class='text-lg'>{projectData.data.project.title}</a>
   </Container>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,7 +8,7 @@ import { getPages } from 'src/utils/pages';
 const projectData = await getEntry('project', 'project');
 const pages = await getPages();
 
-const { pageUuid } = Astro.params;
+const { pageSlug, eventSlug } = Astro.params;
 
 const baseUrl = import.meta.env.PROD
   ? projectData.data.project.slug
@@ -17,7 +17,12 @@ const baseUrl = import.meta.env.PROD
 
 <div class='bg-secondary text-white w-full h-[80px] py-6 sticky top-0 z-20'>
   <Container className='flex flex-row items-center gap-[52px]'>
-    <Sidebar baseUrl={baseUrl} client:load pages={pages} pageUuid={pageUuid} />
+    <Sidebar
+      baseUrl={baseUrl}
+      client:load
+      pages={pages}
+      pageSlug={pageSlug || eventSlug}
+    />
     <a href={`/${baseUrl}`} class='text-lg'>{projectData.data.project.title}</a>
   </Container>
 </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -31,10 +31,9 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
 
   // highlight the current page
   // if there's no page slug, that means we're on the homepage
-  const isSelected = (page: PageCollectionEntry) => {
-    console.log(page);
-    return page.id === props.pageSlug || page.data.slug === props.pageSlug;
-  };
+  const isSelected = (page: PageCollectionEntry) =>
+    page.id === (props.pageSlug || homeUuid) ||
+    page.data.slug === props.pageSlug;
 
   return (
     <>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -6,7 +6,7 @@ import type { PageCollectionEntry } from 'src/utils/pages.ts';
 interface SidebarProps {
   baseUrl: string;
   pages: PageCollectionEntry[];
-  pageSlug?: string;
+  slug?: string;
 }
 
 const getHref = (page: PageCollectionEntry, baseUrl: string) => {
@@ -31,9 +31,11 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
 
   // highlight the current page
   // if there's no page slug, that means we're on the homepage
-  const isSelected = (page: PageCollectionEntry) =>
-    page.id === (props.pageSlug || homeUuid) ||
-    page.data.slug === props.pageSlug;
+  const isSelected = (page: PageCollectionEntry) => {
+    return (
+      page.id === (props.slug || homeUuid) || props.slug === page.data.slug
+    );
+  };
 
   return (
     <>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -6,7 +6,7 @@ import type { PageCollectionEntry } from 'src/utils/pages.ts';
 interface SidebarProps {
   baseUrl: string;
   pages: PageCollectionEntry[];
-  pageUuid?: string;
+  pageSlug?: string;
 }
 
 const getHref = (page: PageCollectionEntry, baseUrl: string) => {
@@ -32,10 +32,8 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
   // highlight the current page
   // if there's no page slug, that means we're on the homepage
   const isSelected = (page: PageCollectionEntry) => {
-    return (
-      page.id === (props.pageUuid || homeUuid) ||
-      props.pageUuid === page.data.slug
-    );
+    console.log(page);
+    return page.id === props.pageSlug || page.data.slug === props.pageSlug;
   };
 
   return (

--- a/src/pages/events/[eventSlug].astro
+++ b/src/pages/events/[eventSlug].astro
@@ -19,17 +19,17 @@ export const getStaticPaths = (async () => {
   const pages = await getPages((page) => page.data.autogenerate.enabled);
 
   return pages.map((page) => ({
-    params: { pageUuid: page.data.slug || page.id },
+    params: { eventSlug: page.data.slug || page.id },
   }));
 }) satisfies GetStaticPaths;
 
-const { pageUuid } = Astro.params;
+const { eventSlug } = Astro.params;
 
-if (!pageUuid) {
+if (!eventSlug) {
   return Astro.redirect(`/${baseUrl}`);
 }
 
-const page = await getPage(pageUuid);
+const page = await getPage(eventSlug);
 
 if (!page.data.autogenerate.type_id) {
   return Astro.redirect(`/${baseUrl}`);

--- a/src/pages/events/[pageSlug].astro
+++ b/src/pages/events/[pageSlug].astro
@@ -19,17 +19,17 @@ export const getStaticPaths = (async () => {
   const pages = await getPages((page) => page.data.autogenerate.enabled);
 
   return pages.map((page) => ({
-    params: { eventSlug: page.data.slug || page.id },
+    params: { pageSlug: page.data.slug || page.id },
   }));
 }) satisfies GetStaticPaths;
 
-const { eventSlug } = Astro.params;
+const { pageSlug } = Astro.params;
 
-if (!eventSlug) {
+if (!pageSlug) {
   return Astro.redirect(`/${baseUrl}`);
 }
 
-const page = await getPage(eventSlug);
+const page = await getPage(pageSlug);
 
 if (!page.data.autogenerate.type_id) {
   return Astro.redirect(`/${baseUrl}`);

--- a/src/pages/pages/[pageSlug].astro
+++ b/src/pages/pages/[pageSlug].astro
@@ -18,17 +18,17 @@ export const getStaticPaths = (async () => {
   const eventPages = await getPages((p) => !p.data.autogenerate.enabled);
 
   return eventPages.map((page) => ({
-    params: { pageUuid: page.data.slug || page.id },
+    params: { pageSlug: page.data.slug || page.id },
   }));
 }) satisfies GetStaticPaths;
 
-const { pageUuid } = Astro.params;
+const { pageSlug } = Astro.params;
 
-if (!pageUuid) {
+if (!pageSlug) {
   return Astro.redirect(`/${baseUrl}`);
 }
 
-const page = await getPage(pageUuid);
+const page = await getPage(pageSlug);
 ---
 
 <Layout title={page.data.title}>


### PR DESCRIPTION
# Summary

This PR fixes a bug that prevented pages with slugs from being correctly identified as the current page by the Sidebar component.

Edit: On a quick re-read, all this PR ended up doing is renaming a few things. I don't think there's any actual changed logic here. But I could definitely replicate #58 when I started and it's definitely fixed on this branch. Something must have changed?