### PR TITLE
Multiple AV file support for audio events

### DIFF
--- a/src/components/EventViewer/AnnotationUI/Annotations/Annotation.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/Annotation.astro
@@ -4,10 +4,10 @@ import { PlayCircleIcon } from '@heroicons/react/24/outline';
 import TagPill from '@components/tags/TagPill';
 import { formatTimestamp } from 'src/utils/player';
 import { getEntry } from 'astro:content';
-import type { Annotation } from '@ty/index';
+import type { Annotation, DisplayedAnnotation } from '@ty/index';
 
 interface Props {
-  ann: Annotation & { set: string };
+  ann: DisplayedAnnotation;
   playerId: string;
   setName?: string;
 }
@@ -22,6 +22,7 @@ const tagGroups = projectData.data.project.tags.tagGroups;
   class='annotationNode flex flex-row justify-between gap-4 p-4 my-4 rounded-md bg-white'
   data-start={ann.start_time}
   data-end={ann.end_time}
+  data-file={ann.file}
   data-tags={JSON.stringify(ann.tags)}
   data-set={ann.set}
   data-uuid={ann.uuid}

--- a/src/components/EventViewer/AnnotationUI/Annotations/AnnotationNanostorePopulator.tsx
+++ b/src/components/EventViewer/AnnotationUI/Annotations/AnnotationNanostorePopulator.tsx
@@ -10,6 +10,7 @@ interface Props {
   annotations: DisplayedAnnotation[];
   playerId: string;
   isEmbed?: boolean;
+  initialFile: string;
 }
 
 const AnnotationNanostorePopulator: React.FC<Props> = (props) => {
@@ -21,6 +22,7 @@ const AnnotationNanostorePopulator: React.FC<Props> = (props) => {
       annotations: [...props.annotations],
       filteredAnnotations: [...props.annotations.map((ann) => ann.uuid)],
       isEmbed: props.isEmbed,
+      avFileUuid: props.initialFile,
     });
   }, [props.annotations, props.playerId, props.isEmbed]);
 

--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -9,9 +9,10 @@ export interface Props {
   annotationSets: CollectionEntry<'annotations'>[];
   type: 'Audio' | 'Video';
   isEmbed?: boolean;
+  initialFile: string;
 }
 
-const { annotationSets, isEmbed, playerId, type } = Astro.props;
+const { annotationSets, initialFile, isEmbed, playerId, type } = Astro.props;
 
 const sortedAnnotations = annotationSets
   .map((set) =>
@@ -19,6 +20,7 @@ const sortedAnnotations = annotationSets
       ...ann,
       set: set.id,
       setName: set.data.set,
+      file: set.data.source_id,
     }))
   )
   .flat()
@@ -27,33 +29,32 @@ const sortedAnnotations = annotationSets
   ) as DisplayedAnnotation[];
 ---
 
-<div class='flex flex-col'>
+<div
+  class=`top-[300px] overflow-y-visible w-full ${type === 'Audio' ? 'sticky' : ''}`
+>
+  <AnnotationNanostorePopulator
+    annotations={sortedAnnotations}
+    playerId={playerId}
+    isEmbed={isEmbed}
+    initialFile={initialFile}
+    client:only='react'
+  />
   <div
-    class=`top-[300px] overflow-y-visible w-full ${type === 'Audio' ? 'sticky' : ''}`
+    class={`${type === 'Video' ? 'overflow-y-scroll max-h-[510px] video videoAnnotationContainer' : ''}`}
+    id={playerId}
+    data-player-id={playerId}
   >
-    <AnnotationNanostorePopulator
-      annotations={sortedAnnotations}
-      playerId={playerId}
-      isEmbed={isEmbed}
-      client:only='react'
-    />
-    <div
-      class={`${type === 'Video' ? 'overflow-y-scroll max-h-[510px] video videoAnnotationContainer' : ''}`}
-      id={playerId}
-      data-player-id={playerId}
-    >
-      {
-        sortedAnnotations.map((ann) => {
-          return (
-            <Annotation
-              ann={ann}
-              playerId={playerId}
-              setName={annotationSets.length > 1 ? ann.setName : undefined}
-            />
-          );
-        })
-      }
-    </div>
+    {
+      sortedAnnotations.map((ann) => {
+        return (
+          <Annotation
+            ann={ann}
+            playerId={playerId}
+            setName={annotationSets.length > 1 ? ann.setName : undefined}
+          />
+        );
+      })
+    }
   </div>
 </div>
 
@@ -164,7 +165,7 @@ const sortedAnnotations = annotationSets
           }
           // otherwise, scroll the whole page
         } else {
-          activeNode.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          activeNode.scrollIntoView({ behavior: 'smooth', block: 'end' });
         }
       }
 
@@ -177,7 +178,7 @@ const sortedAnnotations = annotationSets
       }
     }
 
-    //show or hide tags if necessary
+    // show or hide tags if necessary
     if (state[changed].showTags !== oldState[changed].showTags) {
       if (state[changed].showTags) {
         for (let i = 0; i < annotationTagNodes.length; i++) {

--- a/src/components/EventViewer/AudioEvent.astro
+++ b/src/components/EventViewer/AudioEvent.astro
@@ -6,6 +6,7 @@ import Player from '@components/Player';
 import Annotations from './AnnotationUI/Annotations/index.astro';
 import AnnotationHeader from './AnnotationUI/AnnotationHeader.astro';
 import ConditionalContainer from './ConditionalContainer.astro';
+import AudioFilePicker from './AudioFilePicker';
 
 interface Props extends SlateEventNodeProps {
   annotationSets: CollectionEntry<'annotations'>[];
@@ -26,8 +27,6 @@ const {
   isEmbed,
   playerId,
 } = Astro.props;
-
-const url = event.data.audiovisual_files[file].file_url;
 ---
 
 <div>
@@ -43,19 +42,26 @@ const url = event.data.audiovisual_files[file].file_url;
           )
         }
       </ConditionalContainer>
-      <div
-        class='mediaContainer gap-4 flex flex-col'
-        data-player-id={playerId}
-        data-player-url={url}
-      >
+      <div class='mediaContainer gap-4 flex flex-col' data-player-id={playerId}>
         {
           includes.includes('media') && (
             <ConditionalContainer condition={!isEmbed}>
+              {/* only show the picker if
+                  1. there's more than AV file
+                  2. this is not an embed of a single AV file */}
+              {!start &&
+                !end &&
+                Object.keys(event.data.audiovisual_files).length > 1 && (
+                  <AudioFilePicker
+                    event={event}
+                    playerId={playerId}
+                    client:load
+                  />
+                )}
               <Player
-                url={url}
                 id={playerId}
                 client:only='react'
-                type={event.data.item_type}
+                event={event}
                 start={start}
                 end={end}
               />
@@ -78,6 +84,7 @@ const url = event.data.audiovisual_files[file].file_url;
       isEmbed={isEmbed}
       playerId={playerId}
       type={event.data.item_type}
+      initialFile={file}
     />
   </ConditionalContainer>
 </div>

--- a/src/components/EventViewer/AudioEvent.astro
+++ b/src/components/EventViewer/AudioEvent.astro
@@ -55,7 +55,7 @@ const {
                   <AudioFilePicker
                     event={event}
                     playerId={playerId}
-                    client:load
+                    client:only='react'
                   />
                 )}
               <Player

--- a/src/components/EventViewer/AudioFilePicker.tsx
+++ b/src/components/EventViewer/AudioFilePicker.tsx
@@ -1,0 +1,44 @@
+import { useStore } from '@nanostores/react';
+import type { CollectionEntry } from 'astro:content';
+import { useEffect } from 'react';
+import { PlayFill } from 'react-bootstrap-icons';
+import { $pagePlayersState, setAvFile } from 'src/store.ts';
+import { formatTimestamp } from 'src/utils/player.ts';
+
+interface Props {
+  event: CollectionEntry<'events'>;
+  playerId: string;
+}
+
+const AudioFilePicker: React.FC<Props> = (props) => {
+  const store = useStore($pagePlayersState);
+
+  return (
+    <div className='py-2'>
+      <p>{props.event.data.label}</p>
+      <ol className='flex flex-col gap-2'>
+        {Object.keys(props.event.data.audiovisual_files).map((uuid) => {
+          const avFile = props.event.data.audiovisual_files[uuid];
+
+          return (
+            <li
+              className='flex gap-2 items-center hover:cursor-pointer'
+              onClick={() => setAvFile(uuid, props.playerId)}
+              key={uuid}
+            >
+              <div className='w-4'>
+                {store[props.playerId]?.avFileUuid === uuid && <PlayFill />}
+              </div>
+              <span>{avFile.label}</span>
+              <span className='flex items-center border border-black rounded-[5px] text-xs p-2 font-semibold h-6'>
+                {formatTimestamp(avFile.duration, false)}
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+};
+
+export default AudioFilePicker;

--- a/src/components/EventViewer/AudioFilePicker.tsx
+++ b/src/components/EventViewer/AudioFilePicker.tsx
@@ -17,8 +17,9 @@ const AudioFilePicker: React.FC<Props> = (props) => {
     <div className='py-2'>
       <p>{props.event.data.label}</p>
       <ol className='flex flex-col gap-2'>
-        {Object.keys(props.event.data.audiovisual_files).map((uuid) => {
+        {Object.keys(props.event.data.audiovisual_files).map((uuid, idx) => {
           const avFile = props.event.data.audiovisual_files[uuid];
+          const isCurrentFile = store[props.playerId]?.avFileUuid === uuid;
 
           return (
             <li
@@ -26,10 +27,11 @@ const AudioFilePicker: React.FC<Props> = (props) => {
               onClick={() => setAvFile(uuid, props.playerId)}
               key={uuid}
             >
-              <div className='w-4'>
-                {store[props.playerId]?.avFileUuid === uuid && <PlayFill />}
-              </div>
-              <span>{avFile.label}</span>
+              <div className='w-4'>{isCurrentFile && <PlayFill />}</div>
+              <span className={isCurrentFile ? 'font-bold' : ''}>
+                {idx + 1}. &nbsp;
+                {avFile.label}
+              </span>
               <span className='flex items-center border border-black rounded-[5px] text-xs p-2 font-semibold h-6'>
                 {formatTimestamp(avFile.duration, false)}
               </span>

--- a/src/components/EventViewer/VideoEvent.astro
+++ b/src/components/EventViewer/VideoEvent.astro
@@ -41,10 +41,8 @@ const baseUrl = import.meta.env.PROD
   ? projectData.data.project.slug
   : dynamicConfig.base;
 
-// @ts-ignore
-const url = (event as CollectionEntry<'events'>).data.audiovisual_files[file]
-  .file_url;
 let captionSets: { url: string; label: string }[];
+
 if (
   // @ts-ignore
   (event as CollectionEntry<'events'>).data.audiovisual_files[file].caption_set
@@ -74,7 +72,6 @@ if (
       <div
         class={`mediaContainer gap-4 ${sticky ? 'sticky top-0' : ''} ${event.data.item_type === 'Audio' ? 'flex flex-col' : 'grid grid-cols-[2fr,1fr] lg:gap-x-4'}`}
         data-player-id={playerId}
-        data-player-url={url}
       >
         {includes.includes('media') && (
           <div>
@@ -82,10 +79,9 @@ if (
               <h1 class='py-4'>{event.data.label}</h1>
             )}
             <Player
-              url={url}
               id={playerId}
               client:only='react'
-              type={event.data.item_type}
+              event={event}
               start={start}
               end={end}
               vttURLs={captionSets}
@@ -113,6 +109,7 @@ if (
             <Annotations
               playerId={playerId}
               annotationSets={annotationSets}
+              initialFile={file}
               isEmbed={isEmbed}
               type={event.data.item_type}
             />

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -18,14 +18,14 @@ import {
 import { useStore } from '@nanostores/react';
 import { formatTimestamp } from '../../utils/player.ts';
 import type { OnProgressProps } from 'react-player/base';
+import type { CollectionEntry } from 'astro:content';
 
 interface Props {
   end?: number;
   id: string;
   start?: number;
-  type: 'Audio' | 'Video';
-  url: string;
   vttURLs?: { url: string; label: string }[];
+  event: CollectionEntry<'events'>;
 }
 
 const getSegments = (playerState: AnnotationState): [number, number][] => {
@@ -46,6 +46,12 @@ const Player: React.FC<Props> = (props) => {
 
   const pagePlayers = useStore($pagePlayersState);
   const playerState = pagePlayers[props.id];
+
+  const fileUrl = useMemo(() => {
+    const avFile = props.event.data.audiovisual_files[playerState.avFileUuid];
+
+    return avFile.file_url;
+  }, [pagePlayers[props.id]]);
 
   const segments = useMemo(() => {
     if (playerState.snapToAnnotations) {
@@ -210,7 +216,7 @@ const Player: React.FC<Props> = (props) => {
   return (
     <div className='player'>
       <ReactPlayer
-        controls={props.type === 'Video'}
+        controls={props.event.data.item_type === 'Video'}
         playing={playerState.isPlaying}
         muted={muted}
         config={tracksConfig}
@@ -238,11 +244,11 @@ const Player: React.FC<Props> = (props) => {
         }}
         progressInterval={250}
         ref={player}
-        url={props.url}
-        height={props.type === 'Video' ? '100%' : 0}
-        width={props.type === 'Video' ? '100%' : 0}
+        url={fileUrl}
+        height={props.event.data.item_type === 'Video' ? '100%' : 0}
+        width={props.event.data.item_type === 'Video' ? '100%' : 0}
       />
-      {props.type === 'Audio' && (
+      {props.event.data.item_type === 'Audio' && (
         <div className='player-control-panel !bg-gray-200'>
           <div className='content'>
             <Button

--- a/src/store.ts
+++ b/src/store.ts
@@ -33,6 +33,11 @@ export const $pagePlayersState = deepMap<{ [key: string]: AnnotationState }>(
 const getFilteredAnnotations = (newState: AnnotationState) =>
   newState.annotations
     .filter((ann) => {
+      // hide if its AV file is hidden
+      if (newState.avFileUuid && ann.file !== newState.avFileUuid) {
+        return false;
+      }
+
       // hide if its set is hidden
       if (newState.sets.length > 0) {
         const setFiltersEmpty = newState.sets.length === 0;
@@ -42,7 +47,7 @@ const getFilteredAnnotations = (newState: AnnotationState) =>
         }
       }
 
-      // hide if its sets are hidden
+      // hide if its tags are hidden
       if (newState.tags.length > 0) {
         let match = false;
 
@@ -209,6 +214,19 @@ export const toggleSetFilter = (set: string, playerId: string) => {
       sets: [...thisPlayer.sets, set],
     };
   }
+
+  newState.filteredAnnotations = getFilteredAnnotations(newState);
+
+  $pagePlayersState.setKey(playerId, newState);
+};
+
+export const setAvFile = (avFileUuid: string, playerId: string) => {
+  const oldState = $pagePlayersState.get()[playerId];
+
+  const newState = {
+    ...oldState,
+    avFileUuid,
+  };
 
   newState.filteredAnnotations = getFilteredAnnotations(newState);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,8 +105,8 @@ export type Annotation = {
 };
 
 export type DisplayedAnnotation = Annotation & {
+  file: string;
   set: string;
-
   setName: string;
 };
 


### PR DESCRIPTION
# Summary

This PR updates the audio event viewer to support multiple files, including several use cases:

* When an event contains only 1 AV file, behavior is completely unchanged.
* When an event contains multiple AV files, there is now a list above the player that allows the user to switch between them. (I've also added the `file` attribute to the annotation filtering logic so only annotations from the current file will display)
* When an embedded event contains the entire event *and* the event has more than one AV file, the AV file picker is displayed in the embed.
* When an embedded event contains a *clip*, the picker is not displayed in the embed (because the clip is of only one AV file)
* When an embedded event contains the entire event and the event has only one AV file, no picker is displayed.

A lot of this PR is general enough to be a head start on the video AV file picker, so that PR should come soon after this is merged.