### PR TITLE
Multiple AV file support for video events

### DIFF
--- a/src/components/EventViewer/AnnotationUI/Annotations/Annotation.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/Annotation.astro
@@ -10,16 +10,17 @@ interface Props {
   ann: DisplayedAnnotation;
   playerId: string;
   setName?: string;
+  initialFile: string;
 }
 
-const { ann, playerId, setName } = Astro.props;
+const { ann, initialFile, playerId, setName } = Astro.props;
 
 const projectData = await getEntry('project', 'project');
 const tagGroups = projectData.data.project.tags.tagGroups;
 ---
 
 <div
-  class='annotationNode flex flex-row justify-between gap-4 p-4 my-4 rounded-md bg-white'
+  class={`annotationNode flex flex-row justify-between gap-4 p-4 my-4 rounded-md bg-white ${ann.file === initialFile ? '' : 'hidden'}`}
   data-start={ann.start_time}
   data-end={ann.end_time}
   data-file={ann.file}

--- a/src/components/EventViewer/AnnotationUI/Annotations/AnnotationNanostorePopulator.tsx
+++ b/src/components/EventViewer/AnnotationUI/Annotations/AnnotationNanostorePopulator.tsx
@@ -1,6 +1,6 @@
 import type { DisplayedAnnotation } from '@ty/index.ts';
 import { useStore } from '@nanostores/react';
-import { $pagePlayersState } from 'src/store.ts';
+import { $pagePlayersState, setAvFile } from 'src/store.ts';
 import { useEffect } from 'react';
 
 // This component's only purpose is to populate the
@@ -20,7 +20,11 @@ const AnnotationNanostorePopulator: React.FC<Props> = (props) => {
     $pagePlayersState.setKey(props.playerId, {
       ...store[props.playerId],
       annotations: [...props.annotations],
-      filteredAnnotations: [...props.annotations.map((ann) => ann.uuid)],
+      filteredAnnotations: [
+        ...props.annotations
+          .filter((ann) => ann.file === props.initialFile)
+          .map((ann) => ann.uuid),
+      ],
       isEmbed: props.isEmbed,
       avFileUuid: props.initialFile,
     });

--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -49,6 +49,7 @@ const sortedAnnotations = annotationSets
         return (
           <Annotation
             ann={ann}
+            initialFile={initialFile}
             playerId={playerId}
             setName={annotationSets.length > 1 ? ann.setName : undefined}
           />

--- a/src/components/EventViewer/AudioFilePicker.tsx
+++ b/src/components/EventViewer/AudioFilePicker.tsx
@@ -1,6 +1,5 @@
 import { useStore } from '@nanostores/react';
 import type { CollectionEntry } from 'astro:content';
-import { useEffect } from 'react';
 import { PlayFill } from 'react-bootstrap-icons';
 import { $pagePlayersState, setAvFile } from 'src/store.ts';
 import { formatTimestamp } from 'src/utils/player.ts';

--- a/src/components/EventViewer/VideoEvent.astro
+++ b/src/components/EventViewer/VideoEvent.astro
@@ -9,6 +9,7 @@ import AnnotationHeader from './AnnotationUI/AnnotationHeader.astro';
 import ConditionalContainer from './ConditionalContainer.astro';
 import { getEntry } from 'astro:content';
 import { dynamicConfig } from 'dynamic-astro-config';
+import VideoFilePicker from './VideoFilePicker';
 
 export interface Props {
   event: CollectionEntry<'events'>;
@@ -86,17 +87,13 @@ if (
               end={end}
               vttURLs={captionSets}
             />
-            {includes.includes('description') && event.data.description && (
-              <div class='my-4'>
+            {includes.includes('description')
+              ? (
+              <VideoFilePicker event={event} playerId={playerId}>
                 <RichText nodes={event.data.description} />
-              </div>
-            )}
-            <div class='h-1 border-t border-gray-200 w-full' />
-            {event.data.citation && (
-              <Container>
-                <p>{event.data.citation}</p>
-              </Container>
-            )}
+              </VideoFilePicker>)
+              : <VideoFilePicker event={event} playerId={playerId} />
+            }
           </div>
         )}
         {includes.includes('annotations') && (

--- a/src/components/EventViewer/VideoEvent.astro
+++ b/src/components/EventViewer/VideoEvent.astro
@@ -87,13 +87,35 @@ if (
               end={end}
               vttURLs={captionSets}
             />
-            {includes.includes('description')
-              ? (
-              <VideoFilePicker event={event} playerId={playerId}>
-                <RichText nodes={event.data.description} />
-              </VideoFilePicker>)
-              : <VideoFilePicker event={event} playerId={playerId} />
-            }
+            {includes.includes('description') ? (
+              <>
+                {!start &&
+                !end &&
+                Object.keys(event.data.audiovisual_files).length > 1 ? (
+                  <VideoFilePicker
+                    event={event}
+                    playerId={playerId}
+                    client:load
+                  >
+                    <RichText nodes={event.data.description} />
+                  </VideoFilePicker>
+                ) : (
+                  <RichText nodes={event.data.description} />
+                )}
+              </>
+            ) : (
+              <>
+                {!start &&
+                  !end &&
+                  Object.keys(event.data.audiovisual_files).length > 1 && (
+                    <VideoFilePicker
+                      event={event}
+                      playerId={playerId}
+                      client:load
+                    />
+                  )}
+              </>
+            )}
           </div>
         )}
         {includes.includes('annotations') && (

--- a/src/components/EventViewer/VideoFilePicker.tsx
+++ b/src/components/EventViewer/VideoFilePicker.tsx
@@ -1,0 +1,93 @@
+import { useStore } from '@nanostores/react';
+import type { CollectionEntry } from 'astro:content';
+import { useState } from 'react';
+import { PlayFill } from 'react-bootstrap-icons';
+import { $pagePlayersState, setAvFile } from 'src/store.ts';
+import { formatTimestamp } from 'src/utils/player.ts';
+import RichText from '@components/RichText/index.astro';
+
+interface Props {
+  event: CollectionEntry<'events'>;
+  playerId: string;
+  // "children" is the rich text component for the description.
+  // while we can't render an Astro component from a React component,
+  // we can apparently pass it as a child component inside the React
+  // component!
+  children?: any;
+}
+
+const VideoFilePicker: React.FC<Props> = (props) => {
+  const [tab, setTab] = useState<'desc' | 'picker'>(
+    props.children ? 'desc' : 'picker'
+  );
+  const store = useStore($pagePlayersState);
+
+  const getButtonClassNames = (buttonTab: typeof tab) => {
+    const baseStyle = '';
+
+    if (buttonTab === tab) {
+      return `${baseStyle} underline`;
+    } else {
+      return `${baseStyle} underline text-gray-400`;
+    }
+  };
+
+  return (
+    <div className='py-2'>
+      <div className='flex gap-4'>
+        <button
+          onClick={() => setTab('desc')}
+          role='button'
+          className={getButtonClassNames('desc')}
+        >
+          Description
+        </button>
+        <button
+          onClick={() => setTab('picker')}
+          role='button'
+          className={getButtonClassNames('picker')}
+        >
+          Contents
+        </button>
+      </div>
+      <div>
+        {tab === 'desc' && (
+          <>
+            {props.children}
+            {props.event.data.citation && <p>{props.event.data.citation}</p>}
+          </>
+        )}
+        {tab === 'picker' && (
+          <ol className='flex gap-2 flex-wrap'>
+            {Object.keys(props.event.data.audiovisual_files).map(
+              (uuid, idx) => {
+                const avFile = props.event.data.audiovisual_files[uuid];
+                const isCurrentFile =
+                  store[props.playerId]?.avFileUuid === uuid;
+
+                return (
+                  <li
+                    className='flex gap-2 items-center hover:cursor-pointer'
+                    onClick={() => setAvFile(uuid, props.playerId)}
+                    key={uuid}
+                  >
+                    <div className='w-4'>{isCurrentFile && <PlayFill />}</div>
+                    <span className={isCurrentFile ? 'font-bold' : ''}>
+                      {idx + 1}. &nbsp;
+                      {avFile.label}
+                    </span>
+                    <span className='flex items-center border border-black rounded-[5px] text-xs p-2 font-semibold h-6'>
+                      {formatTimestamp(avFile.duration, false)}
+                    </span>
+                  </li>
+                );
+              }
+            )}
+          </ol>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default VideoFilePicker;

--- a/src/components/EventViewer/VideoFilePicker.tsx
+++ b/src/components/EventViewer/VideoFilePicker.tsx
@@ -1,12 +1,57 @@
 import { useStore } from '@nanostores/react';
 import type { CollectionEntry } from 'astro:content';
-import { useState } from 'react';
-import { PlayFill } from 'react-bootstrap-icons';
+import { useEffect, useRef, useState } from 'react';
 import { $pagePlayersState, setAvFile } from 'src/store.ts';
 import { formatTimestamp } from 'src/utils/player.ts';
-import RichText from '@components/RichText/index.astro';
 
-interface Props {
+interface ThumbCanvasProps {
+  url: string;
+}
+
+const ThumbCanvas: React.FC<ThumbCanvasProps> = (props) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    if (canvasRef.current) {
+      const videoEl = document.createElement('video');
+      videoEl.src = props.url;
+
+      videoEl.onloadeddata = () => {
+        // set the internal canvas dimensions to 2x for better image quality
+        // this doesn't affect CSS, just the canvas's own drawing surface
+        canvasRef.current.height = 180;
+        canvasRef.current.width = 240;
+        const ctx = canvasRef.current.getContext('2d', { alpha: false });
+
+        // draw black background
+        ctx.beginPath();
+        ctx.fillStyle = '#000000';
+        ctx.fillRect(0, 0, canvasRef.current.width, canvasRef.current.height);
+
+        const videoRatio = videoEl.videoHeight / videoEl.videoWidth;
+        const canvasRatio = canvasRef.current.height / canvasRef.current.width;
+
+        if (videoRatio > canvasRatio) {
+          const height = canvasRef.current.width * videoRatio;
+          ctx.drawImage(
+            videoEl,
+            0,
+            Math.floor(canvasRef.current.height - height / 2),
+            canvasRef.current.width,
+            height
+          );
+        } else {
+          const width = (canvasRef.current.width * canvasRatio) / videoRatio;
+          ctx.drawImage(videoEl, 0, 0, width, canvasRef.current.height);
+        }
+      };
+    }
+  }, [props.url, canvasRef.current]);
+
+  return <canvas className='w-[120px] h-[90px]' ref={canvasRef} />;
+};
+
+interface VideoFilePickerProps {
   event: CollectionEntry<'events'>;
   playerId: string;
   // "children" is the rich text component for the description.
@@ -16,19 +61,18 @@ interface Props {
   children?: any;
 }
 
-const VideoFilePicker: React.FC<Props> = (props) => {
+const VideoFilePicker: React.FC<VideoFilePickerProps> = (props) => {
   const [tab, setTab] = useState<'desc' | 'picker'>(
     props.children ? 'desc' : 'picker'
   );
-  const store = useStore($pagePlayersState);
 
   const getButtonClassNames = (buttonTab: typeof tab) => {
-    const baseStyle = '';
+    const baseStyle = 'py-2 mb-4';
 
     if (buttonTab === tab) {
-      return `${baseStyle} underline`;
+      return `${baseStyle} border-b-2 border-solid border-secondary mt-[2px]`;
     } else {
-      return `${baseStyle} underline text-gray-400`;
+      return `${baseStyle} text-gray-400`;
     }
   };
 
@@ -51,40 +95,35 @@ const VideoFilePicker: React.FC<Props> = (props) => {
         </button>
       </div>
       <div>
-        {tab === 'desc' && (
-          <>
-            {props.children}
-            {props.event.data.citation && <p>{props.event.data.citation}</p>}
-          </>
-        )}
-        {tab === 'picker' && (
-          <ol className='flex gap-2 flex-wrap'>
-            {Object.keys(props.event.data.audiovisual_files).map(
-              (uuid, idx) => {
-                const avFile = props.event.data.audiovisual_files[uuid];
-                const isCurrentFile =
-                  store[props.playerId]?.avFileUuid === uuid;
+        <div className={tab !== 'desc' ? 'hidden' : ''}>
+          {props.children}
+          {props.event.data.citation && <p>{props.event.data.citation}</p>}
+        </div>
+        <div
+          className={`grid grid-cols-2 gap-2 py-2 ${
+            tab !== 'picker' ? 'hidden' : ''
+          }`}
+        >
+          {Object.keys(props.event.data.audiovisual_files).map((uuid, idx) => {
+            const avFile = props.event.data.audiovisual_files[uuid];
 
-                return (
-                  <li
-                    className='flex gap-2 items-center hover:cursor-pointer'
-                    onClick={() => setAvFile(uuid, props.playerId)}
-                    key={uuid}
-                  >
-                    <div className='w-4'>{isCurrentFile && <PlayFill />}</div>
-                    <span className={isCurrentFile ? 'font-bold' : ''}>
-                      {idx + 1}. &nbsp;
-                      {avFile.label}
-                    </span>
-                    <span className='flex items-center border border-black rounded-[5px] text-xs p-2 font-semibold h-6'>
-                      {formatTimestamp(avFile.duration, false)}
-                    </span>
-                  </li>
-                );
-              }
-            )}
-          </ol>
-        )}
+            return (
+              <div
+                className='h-[90px] hover:cursor-pointer hover:bg-gray-200 flex gap-2'
+                key={uuid}
+                onClick={() => setAvFile(uuid, props.playerId)}
+              >
+                <ThumbCanvas url={avFile.file_url} />
+                <div className='flex flex-col gap-2'>
+                  <p>
+                    {idx + 1}.&nbsp;{avFile.label}
+                  </p>
+                  <p>{formatTimestamp(avFile.duration, false)}</p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
# Summary

- adds the ability to switch between AV file, when applicable, on video events
  - uses a new Canvas-based component to display the video thumbnails (my Topsters experience came in handy!)
  - the thumbnail will not be shown if anything goes wrong when trying to load it (the title and duration will still be shown)
- fixes an issue where annotations from all files were being shown on initial page load instead of just the ones for the current file

## Testing

The different cases listed in #63 also apply here.

## Screenshot

(The second AV here begins with a black screen - the thumbnail is correct)

<img width="846" alt="Screenshot 2024-10-18 at 2 51 12 PM" src="https://github.com/user-attachments/assets/32d33c40-30e4-45e1-b991-2475e9a0b254">
