### PR TITLE
Better null checking for event description field

### DIFF
--- a/src/components/EventViewer/VideoEvent.astro
+++ b/src/components/EventViewer/VideoEvent.astro
@@ -87,35 +87,25 @@ if (
               end={end}
               vttURLs={captionSets}
             />
-            {includes.includes('description') ? (
-              <>
-                {!start &&
-                !end &&
-                Object.keys(event.data.audiovisual_files).length > 1 ? (
-                  <VideoFilePicker
-                    event={event}
-                    playerId={playerId}
-                    client:load
-                  >
-                    <RichText nodes={event.data.description} />
-                  </VideoFilePicker>
-                ) : (
-                  <RichText nodes={event.data.description} />
-                )}
-              </>
-            ) : (
-              <>
-                {!start &&
-                  !end &&
-                  Object.keys(event.data.audiovisual_files).length > 1 && (
-                    <VideoFilePicker
-                      event={event}
-                      playerId={playerId}
-                      client:load
-                    />
-                  )}
-              </>
-            )}
+            <>
+              {!start &&
+              !end &&
+              Object.keys(event.data.audiovisual_files).length > 1 ? (
+                <VideoFilePicker event={event} playerId={playerId} client:load>
+                  {includes.includes('description') &&
+                    event.data.description && (
+                      <RichText nodes={event.data.description} />
+                    )}
+                </VideoFilePicker>
+              ) : (
+                <>
+                  {includes.includes('description') &&
+                    event.data.description && (
+                      <RichText nodes={event.data.description} />
+                    )}
+                </>
+              )}
+            </>
           </div>
         )}
         {includes.includes('annotations') && (


### PR DESCRIPTION
# Summary

This PR fixes a bug from #68 where the `event.data.description` field wasn't being null-checked before being rendered, resulting in a crash if the field was `null`. It also fixes what seems to be an oversight where the file picker wouldn't be displayed if the user had configured an embedded event to not include a description.