### PR TITLE
Video disappearing bug

### DIFF
--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -43,15 +43,16 @@ const Player: React.FC<Props> = (props) => {
   // total length of recording, in seconds
   const [duration, setDuration] = useState(0);
   const [muted, setMuted] = useState(false);
+  const [url, setUrl] = useState('');
 
   const pagePlayers = useStore($pagePlayersState);
   const playerState = pagePlayers[props.id];
 
-  const fileUrl = useMemo(() => {
+  useEffect(() => {
     const avFile = props.event.data.audiovisual_files[playerState.avFileUuid];
 
-    return avFile.file_url;
-  }, [pagePlayers]);
+    setUrl(avFile.file_url);
+  }, []);
 
   const segments = useMemo(() => {
     if (playerState.snapToAnnotations) {
@@ -244,7 +245,7 @@ const Player: React.FC<Props> = (props) => {
         }}
         progressInterval={250}
         ref={player}
-        url={fileUrl}
+        url={url}
         height={props.event.data.item_type === 'Video' ? '100%' : 0}
         width={props.event.data.item_type === 'Video' ? '100%' : 0}
       />

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -47,11 +47,12 @@ const Player: React.FC<Props> = (props) => {
   const pagePlayers = useStore($pagePlayersState);
   const playerState = pagePlayers[props.id];
 
-  const fileUrl = useMemo(() => {
+  const fileUrl = () => {
+    // @ts-ignore
     const avFile = props.event.data.audiovisual_files[playerState.avFileUuid];
 
     return avFile.file_url;
-  }, [pagePlayers[props.id]]);
+  };
 
   const segments = useMemo(() => {
     if (playerState.snapToAnnotations) {

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -53,7 +53,11 @@ const Player: React.FC<Props> = (props) => {
       const avFile = props.event.data.audiovisual_files[playerState.avFileUuid];
       setUrl(avFile.file_url);
     } else {
-      setUrl(Object.keys(props.event.data.audiovisual_files)[0]);
+      setUrl(
+        props.event.data.audiovisual_files[
+          Object.keys(props.event.data.audiovisual_files)[0]
+        ].file_url
+      );
     }
   }, []);
 

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -54,7 +54,7 @@ const Player: React.FC<Props> = (props) => {
       return avFile.file_url;
     }
 
-    return null;
+    return undefined;
   }, [props.event, playerState]);
 
   const segments = useMemo(() => {

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -47,12 +47,11 @@ const Player: React.FC<Props> = (props) => {
   const pagePlayers = useStore($pagePlayersState);
   const playerState = pagePlayers[props.id];
 
-  const fileUrl = (): string => {
-    // @ts-ignore
+  const fileUrl = useMemo(() => {
     const avFile = props.event.data.audiovisual_files[playerState.avFileUuid];
 
     return avFile.file_url;
-  };
+  }, [pagePlayers]);
 
   const segments = useMemo(() => {
     if (playerState.snapToAnnotations) {
@@ -245,7 +244,7 @@ const Player: React.FC<Props> = (props) => {
         }}
         progressInterval={250}
         ref={player}
-        url={fileUrl()}
+        url={fileUrl}
         height={props.event.data.item_type === 'Video' ? '100%' : 0}
         width={props.event.data.item_type === 'Video' ? '100%' : 0}
       />

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -43,22 +43,18 @@ const Player: React.FC<Props> = (props) => {
   // total length of recording, in seconds
   const [duration, setDuration] = useState(0);
   const [muted, setMuted] = useState(false);
-  const [url, setUrl] = useState('');
 
   const pagePlayers = useStore($pagePlayersState);
   const playerState = pagePlayers[props.id];
 
-  useEffect(() => {
-    if (playerState.avFileUuid && playerState.avFileUuid.length > 0) {
-      const avFile = props.event.data.audiovisual_files[playerState.avFileUuid];
-      setUrl(avFile.file_url);
-    } else {
-      setUrl(
-        props.event.data.audiovisual_files[
-          Object.keys(props.event.data.audiovisual_files)[0]
-        ].file_url
-      );
+  const fileUrl = useMemo(() => {
+    const avFile = props.event.data.audiovisual_files[playerState.avFileUuid];
+
+    if (avFile) {
+      return avFile.file_url;
     }
+
+    return null;
   }, [props.event, playerState]);
 
   const segments = useMemo(() => {
@@ -252,7 +248,7 @@ const Player: React.FC<Props> = (props) => {
         }}
         progressInterval={250}
         ref={player}
-        url={url}
+        url={fileUrl}
         height={props.event.data.item_type === 'Video' ? '100%' : 0}
         width={props.event.data.item_type === 'Video' ? '100%' : 0}
       />

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -49,9 +49,12 @@ const Player: React.FC<Props> = (props) => {
   const playerState = pagePlayers[props.id];
 
   useEffect(() => {
-    const avFile = props.event.data.audiovisual_files[playerState.avFileUuid];
-
-    setUrl(avFile.file_url);
+    if (playerState.avFileUuid && playerState.avFileUuid.length > 0) {
+      const avFile = props.event.data.audiovisual_files[playerState.avFileUuid];
+      setUrl(avFile.file_url);
+    } else {
+      setUrl(Object.keys(props.event.data.audiovisual_files)[0]);
+    }
   }, []);
 
   const segments = useMemo(() => {

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -47,7 +47,7 @@ const Player: React.FC<Props> = (props) => {
   const pagePlayers = useStore($pagePlayersState);
   const playerState = pagePlayers[props.id];
 
-  const fileUrl = () => {
+  const fileUrl = (): string => {
     // @ts-ignore
     const avFile = props.event.data.audiovisual_files[playerState.avFileUuid];
 
@@ -245,7 +245,7 @@ const Player: React.FC<Props> = (props) => {
         }}
         progressInterval={250}
         ref={player}
-        url={fileUrl}
+        url={fileUrl()}
         height={props.event.data.item_type === 'Video' ? '100%' : 0}
         width={props.event.data.item_type === 'Video' ? '100%' : 0}
       />

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -59,7 +59,7 @@ const Player: React.FC<Props> = (props) => {
         ].file_url
       );
     }
-  }, []);
+  }, [props.event, playerState]);
 
   const segments = useMemo(() => {
     if (playerState.snapToAnnotations) {


### PR DESCRIPTION
# Summary

During page transitions on production builds, the video often fails to render because the state is not updating correctly and the code was unable to retrieve the file URL.  This PR changes the flow somewhat to ensure that at least one AV file URL is present on page loads.