### PR TITLE
Fix sidebar current page detection for pages without slugs

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -47,7 +47,9 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
       return true;
     }
 
-    return props.slug && props.slug === page.data.slug;
+    return (
+      props.slug && (props.slug === page.data.slug || props.slug === page.id)
+    );
   };
 
   return (


### PR DESCRIPTION
# Summary

This PR fixes an issue where pages without slugs were failing to be detected as the current page. This was happening because the sidebar was only comparing the page's `slug` attribute. Pages without slugs are given path names using their UUIDs, so the sidebar needed to compare UUIDs too.