### PR TITLE
Replace all `client:only` props with `client:load`

### DIFF
--- a/src-aviary/pages/index.astro
+++ b/src-aviary/pages/index.astro
@@ -1,19 +1,19 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import {Player} from '../components/Player';
+import { Player } from '../components/Player';
 
-const url = `${Astro.url.origin}${Astro.url.pathname}/manifests/manifest.json`
+const url = `${Astro.url.origin}${Astro.url.pathname}/manifests/manifest.json`;
 ---
 
-<Layout title="Welcome to Astro.">
-	<main>
-		<Player manifestURL={url} client:only="react"/>
-	</main>
+<Layout title='Welcome to Astro.'>
+  <main>
+    <Player manifestURL={url} client:load />
+  </main>
 </Layout>
 
 <style>
-	main {
-		font-size: 20px;
-		line-height: 1.6;
-	}
+  main {
+    font-size: 20px;
+    line-height: 1.6;
+  }
 </style>

--- a/src/components/EventViewer/AnnotationUI/AnnotationHeader.astro
+++ b/src/components/EventViewer/AnnotationUI/AnnotationHeader.astro
@@ -47,7 +47,7 @@ const { annotationSets, isComparison, playerId, type } = Astro.props;
         />
         {
           (type === 'Audio' || isComparison) && (
-            <AnnotationSettingsMenu playerId={playerId} client:only='react' />
+            <AnnotationSettingsMenu playerId={playerId} client:load />
           )
         }
       </div>

--- a/src/components/EventViewer/AnnotationUI/AnnotationHeader.astro
+++ b/src/components/EventViewer/AnnotationUI/AnnotationHeader.astro
@@ -28,7 +28,7 @@ const { annotationSets, isComparison, playerId, type } = Astro.props;
         >
           {!isComparison && <h3 class='font-bold text-lg'>Annotations</h3>}
           {type === 'Video' && !isComparison && (
-            <AnnotationSettingsMenu playerId={playerId} client:only='react' />
+            <AnnotationSettingsMenu playerId={playerId} client:load />
           )}
         </div>
       )
@@ -37,13 +37,13 @@ const { annotationSets, isComparison, playerId, type } = Astro.props;
     <div
       class={`flex flex-row gap-8 items-center ${type === 'Video' ? 'w-full justify-between pb-4 z-10 shadow-[0px_4px_2px_-2px_#00000040]' : ''}`}
     >
-      <TextSearch playerId={playerId} client:only='react' />
+      <TextSearch playerId={playerId} client:load />
       <div class='flex gap-4'>
         <TagFilter
           annotationSets={annotationSets}
           playerId={playerId}
           projectData={projectData}
-          client:only='react'
+          client:load
         />
         {
           (type === 'Audio' || isComparison) && (

--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -151,36 +151,38 @@ if (initialTag) {
             startTimes[idx + 1].start > state[changed].position
         : time.start <= state[changed].position;
     });
+
     if (typeof current === 'number' && current >= 0) {
       const activeNode = annotationNodes[current] as HTMLElement;
 
-      if (state[changed].autoScroll) {
-        // scroll the parent element if we're in an embed
-        if (state[changed].isEmbed) {
-          const videoContainerEl = document.querySelector(
-            `.videoAnnotationContainer[data-player-id="${changed}"]`
-          );
-          const offsetTop = activeNode.offsetTop;
+      if (activeNode) {
+        if (state[changed].autoScroll) {
+          // scroll the parent element if we're in an embed
+          if (state[changed].isEmbed) {
+            const videoContainerEl = document.querySelector(
+              `.videoAnnotationContainer[data-player-id="${changed}"]`
+            );
+            const offsetTop = activeNode.offsetTop;
 
-          // we need to scroll a different container if we're in an embedded video event
-          if (videoContainerEl) {
-            videoContainerEl.scroll({
-              top: offsetTop - videoContainerEl.clientHeight,
-              behavior: 'smooth',
-            });
+            // we need to scroll a different container if we're in an embedded video event
+            if (videoContainerEl) {
+              videoContainerEl.scroll({
+                top: offsetTop - videoContainerEl.clientHeight,
+                behavior: 'smooth',
+              });
+            } else {
+              eventContainerEl.scroll({
+                top: offsetTop - eventContainerEl.clientHeight / 3,
+                behavior: 'smooth',
+              });
+            }
+            // otherwise, scroll the whole page
           } else {
-            eventContainerEl.scroll({
-              top: offsetTop - eventContainerEl.clientHeight / 3,
-              behavior: 'smooth',
-            });
+            activeNode.scrollIntoView({ behavior: 'smooth', block: 'end' });
           }
-          // otherwise, scroll the whole page
-        } else {
-          activeNode.scrollIntoView({ behavior: 'smooth', block: 'end' });
         }
+        activeNode.classList.add(activeBackground);
       }
-
-      activeNode.classList.add(activeBackground);
 
       for (let i = 0; i < annotationNodes.length; i++) {
         if (i !== current) {

--- a/src/components/EventViewer/AnnotationUI/TagFilter.tsx
+++ b/src/components/EventViewer/AnnotationUI/TagFilter.tsx
@@ -11,6 +11,7 @@ import {
   XMarkIcon,
 } from '@heroicons/react/24/outline';
 import { useStore } from '@nanostores/react';
+import { defaultState } from '@utils/player.ts';
 import type { CollectionEntry } from 'astro:content';
 import React, { useMemo } from 'react';
 import {
@@ -31,7 +32,7 @@ const TagFilter = (props: TagFilterProps) => {
   const { playerId } = props;
   const playerState = useStore($pagePlayersState);
   const thisPlayer = useMemo(
-    () => playerState[playerId],
+    () => playerState[playerId] || { ...defaultState },
     [playerState, playerId]
   );
 

--- a/src/components/EventViewer/AnnotationUI/TextSearch.tsx
+++ b/src/components/EventViewer/AnnotationUI/TextSearch.tsx
@@ -1,6 +1,7 @@
 import { Input } from '@headlessui/react';
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import { useStore } from '@nanostores/react';
+import { defaultState } from '@utilsplayer.ts';
 import { $pagePlayersState, setSearchFilter } from 'src/store.ts';
 
 export interface TextSearchProps {
@@ -11,6 +12,8 @@ const TextSearch = (props: TextSearchProps) => {
   const { playerId } = props;
   const pagePlayers = useStore($pagePlayersState);
 
+  const playerState = pagePlayers[playerId] || { ...defaultState };
+
   const handleChange = (e: any) => {
     setSearchFilter(e.target.value, playerId);
   };
@@ -19,7 +22,7 @@ const TextSearch = (props: TextSearchProps) => {
     <div className='flex flex-row rounded-lg py-1.5 px-3 bg-white items-center gap-3 border-solid border border-gray-200'>
       <MagnifyingGlassIcon className='h-6 w-6' />
       <Input
-        value={pagePlayers[playerId].searchQuery}
+        value={playerState.searchQuery}
         onChange={handleChange}
         placeholder='Search'
         className='focus:outline-none data-[focus]:outline-2 data-[focus]:-outline-offset-2 data-[focus]:outline-white/25'

--- a/src/components/EventViewer/AudioEvent.astro
+++ b/src/components/EventViewer/AudioEvent.astro
@@ -78,14 +78,15 @@ const {
                   <AudioFilePicker
                     event={event}
                     playerId={playerId}
-                    client:only='react'
+                    client:load
                   />
                 )}
               <Player
                 id={playerId}
-                client:only='react'
+                client:load
                 event={event}
                 start={start}
+                initialFile={file}
                 end={end}
               />
             </ConditionalContainer>

--- a/src/components/EventViewer/AudioEvent.astro
+++ b/src/components/EventViewer/AudioEvent.astro
@@ -52,7 +52,8 @@ const {
                 <ComparisonFilePicker
                   event={event}
                   playerId={playerId}
-                  client:only='react'
+                  initialFile={file}
+                  client:load
                 />
               )
           }

--- a/src/components/EventViewer/AudioFilePicker.tsx
+++ b/src/components/EventViewer/AudioFilePicker.tsx
@@ -2,7 +2,7 @@ import { useStore } from '@nanostores/react';
 import type { CollectionEntry } from 'astro:content';
 import { PlayFill } from 'react-bootstrap-icons';
 import { $pagePlayersState, setAvFile } from 'src/store.ts';
-import { formatTimestamp } from 'src/utils/player.ts';
+import { defaultState, formatTimestamp } from 'src/utils/player.ts';
 
 interface Props {
   event: CollectionEntry<'events'>;
@@ -12,13 +12,20 @@ interface Props {
 const AudioFilePicker: React.FC<Props> = (props) => {
   const store = useStore($pagePlayersState);
 
+  const playerState = store[props.playerId] || { ...defaultState };
+
+  // default to the first file for SSR
+  const currentFile =
+    playerState.avFileUuid ||
+    Object.keys(props.event.data.audiovisual_files)[0];
+
   return (
     <div className='py-2'>
       <p>{props.event.data.label}</p>
       <ol className='flex flex-col gap-2'>
         {Object.keys(props.event.data.audiovisual_files).map((uuid, idx) => {
           const avFile = props.event.data.audiovisual_files[uuid];
-          const isCurrentFile = store[props.playerId]?.avFileUuid === uuid;
+          const isCurrentFile = uuid === currentFile;
 
           return (
             <li

--- a/src/components/EventViewer/ComparisonFilePicker.tsx
+++ b/src/components/EventViewer/ComparisonFilePicker.tsx
@@ -3,31 +3,29 @@ import * as Select from '@radix-ui/react-select';
 import { ChevronDownIcon } from '@radix-ui/themes';
 import { useStore } from '@nanostores/react';
 import { $pagePlayersState, setAvFile } from 'src/store.ts';
-import { useMemo } from 'react';
+import { defaultState } from '@utils/player.ts';
 
 interface Props {
   event: CollectionEntry<'events'>;
   playerId: string;
+  initialFile: string;
 }
 
 const ComparisonFilePicker: React.FC<Props> = (props) => {
   const store = useStore($pagePlayersState);
 
-  if (!store[props.playerId]?.avFileUuid) {
-    return null;
-  }
+  const playerState = store[props.playerId] || { ...defaultState };
+
+  const avFileUuid = playerState.avFileUuid || props.initialFile;
 
   return (
     <Select.Root
       onValueChange={(val) => setAvFile(val, props.playerId)}
-      value={store[props.playerId].avFileUuid}
+      value={avFileUuid}
     >
       <Select.Trigger className='w-[280px] h-[38px] rounded border border-gray-200 bg-white flex justify-between items-center px-4'>
         <Select.Value>
-          {
-            props.event.data.audiovisual_files[store[props.playerId].avFileUuid]
-              .label
-          }
+          {props.event.data.audiovisual_files[avFileUuid].label}
         </Select.Value>
         <Select.Icon>
           <ChevronDownIcon />

--- a/src/components/EventViewer/VideoEvent.astro
+++ b/src/components/EventViewer/VideoEvent.astro
@@ -54,11 +54,12 @@ const captionSets = await getCaptionSets(event, file, annotationSets);
             )}
             <Player
               id={playerId}
-              client:only='react'
+              client:load
               event={event}
               start={start}
               end={end}
               vttURLs={captionSets}
+              initialFile={file}
             />
             <>
               {!start &&

--- a/src/components/EventViewer/VideoEventCompare.astro
+++ b/src/components/EventViewer/VideoEventCompare.astro
@@ -45,7 +45,8 @@ const captionSets = await getCaptionSets(event, defaultFile, annotationSets);
         <ComparisonFilePicker
           event={event}
           playerId={playerId}
-          client:only='react'
+          initialFile={defaultFile}
+          client:load
         />
       )
     }
@@ -60,10 +61,11 @@ const captionSets = await getCaptionSets(event, defaultFile, annotationSets);
         />
         <Player
           id={playerId}
-          client:only='react'
+          client:load
           event={event}
           start={start}
           end={end}
+          initialFile={defaultFile}
           vttURLs={captionSets}
         />
       </>

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -16,7 +16,7 @@ import {
   type AnnotationState,
 } from '../../store.ts';
 import { useStore } from '@nanostores/react';
-import { formatTimestamp } from '../../utils/player.ts';
+import { defaultState, formatTimestamp } from '../../utils/player.ts';
 import type { OnProgressProps } from 'react-player/base';
 import type { CollectionEntry } from 'astro:content';
 
@@ -25,6 +25,7 @@ interface Props {
   id: string;
   start?: number;
   vttURLs?: { url: string; label: string }[];
+  initialFile: string;
   event: CollectionEntry<'events'>;
 }
 
@@ -45,9 +46,14 @@ const Player: React.FC<Props> = (props) => {
   const [muted, setMuted] = useState(false);
 
   const pagePlayers = useStore($pagePlayersState);
-  const playerState = pagePlayers[props.id];
+  const playerState = pagePlayers[props.id] || { ...defaultState };
 
   const fileUrl = useMemo(() => {
+    // initial value for SSR
+    if (!playerState.avFileUuid) {
+      return props.event.data.audiovisual_files[props.initialFile].file_url;
+    }
+
     const avFile = props.event.data.audiovisual_files[playerState.avFileUuid];
 
     if (avFile) {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -60,6 +60,7 @@ const projectBy =
 </html>
 
 <script>
+  import { defaultState } from '@utils/player.ts';
   import { $pagePlayersState } from 'src/store.ts';
   // initially, reset the loaded players to none
   $pagePlayersState.set({});
@@ -68,21 +69,8 @@ const projectBy =
     const thisNode = players[i];
     if (thisNode instanceof HTMLElement && thisNode.dataset.playerId) {
       $pagePlayersState.setKey(thisNode.dataset.playerId, {
-        annotations: [],
-        annotationStarts: [],
-        autoScroll: true,
-        avFileUuid: '',
-        currentAnnotation: 0,
+        ...defaultState,
         id: thisNode.dataset.playerUrl || '',
-        isPlaying: false,
-        filteredAnnotations: [],
-        position: 0,
-        searchQuery: '',
-        seekTo: 0,
-        sets: [],
-        snapToAnnotations: false,
-        showTags: true,
-        tags: [],
       });
     }
   }

--- a/src/pages/tags/detail/[category]/[tag].astro
+++ b/src/pages/tags/detail/[category]/[tag].astro
@@ -152,7 +152,12 @@ for (const set of annotationSets) {
             <h3 class='text-lg py-4'>
               {sd.event.data.audiovisual_files[sd.set.data.source_id].label}
             </h3>
-            <Player id={sd.spectrumId} event={sd.event} client:only='react' />
+            <Player
+              id={sd.spectrumId}
+              event={sd.event}
+              initialFile={sd.set.data.source_id}
+              client:load
+            />
             <Annotations
               playerId={sd.spectrumId}
               annotationSets={[sd.set]}

--- a/src/utils/player.ts
+++ b/src/utils/player.ts
@@ -14,3 +14,21 @@ export const formatTimestamp = (seconds: number, includeMs = false) => {
 
   return str;
 };
+
+export const defaultState = {
+  annotations: [],
+  annotationStarts: [],
+  autoScroll: true,
+  avFileUuid: '',
+  currentAnnotation: 0,
+  id: '',
+  isPlaying: false,
+  filteredAnnotations: [],
+  position: 0,
+  searchQuery: '',
+  seekTo: 0,
+  sets: [],
+  snapToAnnotations: false,
+  showTags: true,
+  tags: [],
+};


### PR DESCRIPTION
# Summary

This PR replaces all instances of `client:only` with `client:load`, addressing #45.

The difference here is that `client:only` components are fetched by the browser at runtime, through a separate network request for each component contained within what Astro calls an island. This causes a slight delay, especially in deployed environments, as the browser makes dozens of requests for each Astro island.

`client:load` will include the component in the initial statically generated page, so it's already there on page load. It's then *hydrated* with whatever props/data are provided at runtime. This is only possible if the component has the props and data it needs to render at the time of page generation, and if the component's first clientside render has the same DOM tree as the server-side render. To accomodate these requirements, this PR adds a couple things:

* new `defaultState` object that components can read from when the player state doesn't exist (i.e. during serverside rendering)
* some default values in certain components to satisfy Astro's requirement that the first client render should be the same as the server

Whichever PR between #75 and this one is merged second will need to be updated, as that PR adds a few new `client:only` spots.