### PR TITLE
Update spacing for `p` tags in rich text blocks

### DIFF
--- a/src/components/RichText/RichTextElement.astro
+++ b/src/components/RichText/RichTextElement.astro
@@ -123,7 +123,7 @@ const getImageClass = (size: 'thumbnail' | 'medium' | 'large' | 'full') => {
         );
       default:
         return (
-          <p class='min-h-8 leading-8' style={style} {...attributes}>
+          <p class='min-h-6 leading-6' style={style} {...attributes}>
             <slot />
           </p>
         );

--- a/src/components/RichText/RichTextElement.astro
+++ b/src/components/RichText/RichTextElement.astro
@@ -123,7 +123,7 @@ const getImageClass = (size: 'thumbnail' | 'medium' | 'large' | 'full') => {
         );
       default:
         return (
-          <p style={style} {...attributes}>
+          <p class='min-h-8 leading-8' style={style} {...attributes}>
             <slot />
           </p>
         );


### PR DESCRIPTION
# Summary

By default, browsers assign a height of 0 to empty `p` elements (`<p></p>`), so empty new lines created in the rich text editor didn't seem to display here in the project client. This PR updates the `RichText` component to require a minimum height on `p` elements that matches the line height so those empty paragraphs will take up vertical space on the page.