### PR TITLE
Possible annotation crash fix

### DIFF
--- a/src/components/EventViewer/AnnotationUI/TagFilter.tsx
+++ b/src/components/EventViewer/AnnotationUI/TagFilter.tsx
@@ -42,7 +42,7 @@ const TagFilter = (props: TagFilterProps) => {
     const tagsObj: { [key: string]: { tags: string[]; color: string } } = {};
 
     const setsToShow =
-      thisPlayer.sets.length > 0
+      thisPlayer.sets?.length > 0
         ? props.annotationSets.filter((set) => thisPlayer.sets.includes(set.id))
         : props.annotationSets;
 


### PR DESCRIPTION
# Summary

This PR is an attempt to fix a crash that only (sporadically) occurs in production. The minified error messages we get on prod were enough to narrow it down to one particular spot, `thisPlayer.sets.length` in the tag filter component.

`thisPlayer.sets` should never be undefined, as it's populated by the `defaultState` object when the player state isn't available yet. But I can't imagine that this error could be happening anywhere else. I don't see a place where the `sets` value could be anything other than an array.

So this PR adds a `?` to make it `thisPlayer.sets?.length`. We'll see if the bug continues to happen...