### PR TITLE
Use the correct state value in populator components

### DIFF
--- a/src/components/EventViewer/AnnotationUI/Annotations/AnnotationNanostorePopulator.tsx
+++ b/src/components/EventViewer/AnnotationUI/Annotations/AnnotationNanostorePopulator.tsx
@@ -1,5 +1,4 @@
 import type { DisplayedAnnotation } from '@ty/index.ts';
-import { useStore } from '@nanostores/react';
 import { $pagePlayersState } from 'src/store.ts';
 import { useEffect } from 'react';
 
@@ -13,11 +12,11 @@ interface Props {
 }
 
 const AnnotationNanostorePopulator: React.FC<Props> = (props) => {
-  const store = useStore($pagePlayersState);
-
   useEffect(() => {
+    const state = $pagePlayersState.get()[props.playerId];
+
     $pagePlayersState.setKey(props.playerId, {
-      ...store[props.playerId],
+      ...state,
       annotations: [...props.annotations],
       filteredAnnotations: [
         ...props.annotations

--- a/src/components/EventViewer/PlayerStateNanostorePopulator.tsx
+++ b/src/components/EventViewer/PlayerStateNanostorePopulator.tsx
@@ -1,4 +1,3 @@
-import { useStore } from '@nanostores/react';
 import { $pagePlayersState } from 'src/store.ts';
 import { useEffect } from 'react';
 
@@ -12,11 +11,11 @@ interface Props {
 }
 
 const PlayerStateNanostorePopulator: React.FC<Props> = (props) => {
-  const store = useStore($pagePlayersState);
-
   useEffect(() => {
+    const state = $pagePlayersState.get()[props.playerId];
+
     $pagePlayersState.setKey(props.playerId, {
-      ...store[props.playerId],
+      ...state,
       isEmbed: props.isEmbed,
       avFileUuid: props.initialFile,
     });


### PR DESCRIPTION
# Summary

Thanks to the logging from #88, I might have found the cause of #82.

The two React components we use to manage the nanostore for some of the clientside config were updating it with syntax like:

```ts
  useEffect(() => {
    $pagePlayersState.setKey(props.playerId, {
      ...store[props.playerId],
      isEmbed: props.isEmbed,
      avFileUuid: props.initialFile,
    });
  }, [props.playerId, props.isEmbed]);
```

It appears that `store[props.playerId]` was being evaluated as soon as the component mounted. If this component mounted before the JS that populates the initial store was finished running, then `store[props.playerId]` would resolve to either `undefined` or `{}`. (Surprisingly, `{ ...undefined }` doesn't seem to cause a JS error - it's treated as equivalent to `{}`).

The large number of sets/annotations on the test project probably caused the nanostore initializer JS to take more time, meaning this issue was more likely on large and complex projects.

Just adding `store` to the `useEffect` dependency array would cause an infinite loop, so I reverted it to the standard `$pagePlayersState.get()` method to make sure these `useEffect` hooks are always basing their updates on the latest state.