### PR TITLE
Use default state when updating state if player state doesn't exist

### DIFF
--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -70,6 +70,7 @@ if (initialTag) {
 </div>
 
 <script>
+  import { defaultState } from '@utils/player.ts';
   import { $pagePlayersState } from 'src/store.ts';
 
   const hideNode = (node: HTMLElement | Element) => {
@@ -103,14 +104,15 @@ if (initialTag) {
               : undefined,
         });
         $pagePlayersState.setKey(thisNode.dataset.playerId, {
-          ...$pagePlayersState.get()[thisNode.dataset.playerId],
+          ...($pagePlayersState.get()[thisNode.dataset.playerId] ||
+            defaultState),
           annotationStarts: annotationStartsNew,
         });
       }
       thisNode.addEventListener('click', () => {
         const playerId = thisNode.dataset.playerId || 'null';
         $pagePlayersState.setKey(playerId, {
-          ...$pagePlayersState.get()[playerId],
+          ...($pagePlayersState.get()[playerId] || defaultState),
           position: Number(thisNode.dataset.start),
           seekTo: Number(thisNode.dataset.start),
           isPlaying: true,

--- a/src/components/EventViewer/VideoFilePicker.tsx
+++ b/src/components/EventViewer/VideoFilePicker.tsx
@@ -1,7 +1,6 @@
-import { useStore } from '@nanostores/react';
 import type { CollectionEntry } from 'astro:content';
 import { useEffect, useRef, useState } from 'react';
-import { $pagePlayersState, setAvFile } from 'src/store.ts';
+import { setAvFile } from 'src/store.ts';
 import { formatTimestamp } from 'src/utils/player.ts';
 
 interface ThumbCanvasProps {


### PR DESCRIPTION
# Summary

Extending on #89 (which was on the right track), this PR updates the two state updates in the Annotations Astro component's clientside JS to use the default state if the current player state is `undefined`.