### PR TITLE
Allow the file_url to be null

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -33,7 +33,7 @@ const eventCollection = defineCollection({
       z.object({
         label: z.string(),
         is_offline: z.boolean().nullish(),
-        file_url: z.string(),
+        file_url: z.string().nullish(),
         duration: z.number(),
         caption_set: z
           .array(


### PR DESCRIPTION
# Summary

This PR removes the requirement for a file_url for AV files from the Astro Content schema.

