### PR TITLE
Add `line-break` node support to RichText

### DIFF
--- a/src/components/RichText/RichTextElement.astro
+++ b/src/components/RichText/RichTextElement.astro
@@ -25,6 +25,8 @@ const getImageClass = (size: 'thumbnail' | 'medium' | 'large' | 'full') => {
     const style = { textAlign: element.align };
 
     switch (element.type) {
+      case 'line-break':
+        return <br />;
       case 'block-quote':
         return (
           <blockquote style={style} {...attributes}>


### PR DESCRIPTION
# Summary

This goes along with https://github.com/AVAnnotate/admin-client/pull/194 by enabling support for the new `line-break` element in the `RichText` Astro component.