### PR TITLE
Fix timestamp spacing in annotation list

### DIFF
--- a/src/components/EventViewer/AnnotationUI/Annotations/Annotation.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/Annotation.astro
@@ -28,7 +28,7 @@ const tagGroups = projectData.data.project.tags.tagGroups;
   data-set={ann.set}
   data-uuid={ann.uuid}
 >
-  <div class='flex flex-row gap-2 w-[140px] items-start'>
+  <div class='flex flex-row gap-2 w-[120px] items-start'>
     <button
       class='playAnnotation'
       data-start={ann.start_time}
@@ -37,8 +37,8 @@ const tagGroups = projectData.data.project.tags.tagGroups;
     >
       <PlayCircleIcon className='h-6 w-6' />
     </button>
-    <p class='w-[140px] font-semibold text-sm'>
-      {`${formatTimestamp(ann.start_time)}`}&nbsp;-&nbsp;{
+    <p class='font-semibold text-sm'>
+      {`${formatTimestamp(ann.start_time)}`}&nbsp;- {
         `${formatTimestamp(ann.end_time)}`
       }
     </p>


### PR DESCRIPTION
# Summary

This PR fixes a styling issue that occurred in Chrome across all annotation list components, where the timestamp text was overflowing its horizontal bounds and overlapping with the annotation text.

## Before

See https://github.com/AVAnnotate/project-client/issues/98

## After

<img width="453" alt="Screenshot 2024-11-12 at 4 05 46 PM" src="https://github.com/user-attachments/assets/51381791-9691-43bd-b369-d1284bcc0f7d">
