### PR TITLE
Annotation header wrapping

### DIFF
--- a/src/components/EventViewer/AnnotationUI/AnnotationHeader.astro
+++ b/src/components/EventViewer/AnnotationUI/AnnotationHeader.astro
@@ -35,7 +35,7 @@ const { annotationSets, isComparison, playerId, type } = Astro.props;
     }
     {type === 'Video' && <div class='h-1 border-t border-gray-200 w-full' />}
     <div
-      class={`flex flex-row gap-8 items-center ${type === 'Video' ? 'w-full justify-between pb-4 z-10 shadow-[0px_4px_2px_-2px_#00000040]' : ''}`}
+      class={`flex flex-row flex-wrap gap-8 items-center ${type === 'Video' ? 'w-full justify-between pb-4 z-10 shadow-[0px_4px_2px_-2px_#00000040]' : ''}`}
     >
       <TextSearch playerId={playerId} client:load />
       <div class='flex gap-4'>

--- a/src/components/EventViewer/AnnotationUI/TextSearch.tsx
+++ b/src/components/EventViewer/AnnotationUI/TextSearch.tsx
@@ -19,7 +19,7 @@ const TextSearch = (props: TextSearchProps) => {
   };
 
   return (
-    <div className='flex flex-row rounded-lg py-1.5 px-3 bg-white items-center gap-3 border-solid border border-gray-200'>
+    <div className='flex flex-row grow rounded-lg py-1.5 px-3 bg-white items-center gap-3 border-solid border border-gray-200'>
       <MagnifyingGlassIcon className='h-6 w-6' />
       <Input
         value={playerState.searchQuery}


### PR DESCRIPTION
# Summary

This PR adds flex wrapping to the annotation header bar so the buttons don't get squished in narrow containers (especially, but not exclusively, event comparisons on narrower screens).

<img width="370" alt="Screenshot 2024-11-12 at 4 15 57 PM" src="https://github.com/user-attachments/assets/c9fe9ce5-1b7f-42a4-8332-3504dd448fa7">

The layout is unchanged if there's enough room, but on a narrow screen the buttons will automatically wrap to the next line and the search box will expand to take up its whole row.