### PR TITLE
Capitalize every word in tag names on index pages

### DIFF
--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -26,7 +26,7 @@ export const fromTagParam = (str: string) => {
 };
 
 // format a tag for display by capitalizing the first character of each word
-// handling the special case of the uncategorized category
+// and handling the special case of the uncategorized category
 export const getTagDisplay = (str: string) => {
   if (str === '_uncategorized_') {
     return 'Uncategorized';

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -25,14 +25,18 @@ export const fromTagParam = (str: string) => {
   return str.replaceAll('_', ' ');
 };
 
-// format a tag for display by capitalizing the first character and
+// format a tag for display by capitalizing the first character of each word
 // handling the special case of the uncategorized category
 export const getTagDisplay = (str: string) => {
   if (str === '_uncategorized_') {
     return 'Uncategorized';
   }
 
-  return `${str[0].toLocaleUpperCase()}${str.slice(1)}`;
+  const split = str.split(' ');
+
+  return split
+    .map((str) => `${str[0].toLocaleUpperCase()}${str.slice(1)}`)
+    .join(' ');
 };
 
 // converts a tag or category name to a format more friendly to URLs


### PR DESCRIPTION
# Summary

This PR updates the `getTagDisplay` function used across the index pages to capitalize every word in a tag, instead of just the first word. The previous behavior looked weird when people's names were used as tags.