### PR TITLE
UI for audio file picker & offline files

### DIFF
--- a/src/components/EventViewer/AudioFilePicker.tsx
+++ b/src/components/EventViewer/AudioFilePicker.tsx
@@ -38,9 +38,6 @@ const AudioFilePicker: React.FC<Props> = (props) => {
                 {idx + 1}. &nbsp;
                 {avFile.label}
               </span>
-              <span className='flex items-center border border-black rounded-[5px] text-xs p-2 font-semibold h-6'>
-                {formatTimestamp(avFile.duration, false)}
-              </span>
             </li>
           );
         })}

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -261,65 +261,71 @@ const Player: React.FC<Props> = (props) => {
         height={props.event.data.item_type === 'Video' ? '100%' : 0}
         width={props.event.data.item_type === 'Video' ? '100%' : 0}
       />
-      {props.event.data.item_type === 'Audio' && (
-        <div className='player-control-panel !bg-gray-200'>
-          <div className='content'>
-            <Button
-              className='audio-button unstyled'
-              onClick={() => {
-                $pagePlayersState.setKey(props.id, {
-                  ...playerState,
-                  isPlaying: !playerState.isPlaying,
-                });
-              }}
-            >
-              {playerState.isPlaying ? (
-                <PauseFill color='black' />
-              ) : (
-                <PlayFill color='black' />
-              )}
-            </Button>
-            <div className='position-label'>
-              <span className='timestamp position'>{formattedPosition}</span>
-              <span>&nbsp;/&nbsp;</span>
-              <span className='timestamp duration'>{formattedDuration}</span>
-            </div>
-            <div className='seek-bar'>
-              <Slider.Root
-                className='seek-bar-slider'
-                defaultValue={[props.start ? props.start / duration : 0]}
-                min={props.start ? props.start / duration : 0}
-                max={0.999999999}
-                onValueChange={(val) => {
-                  setSeeking(true);
+      {props.event.data.item_type === 'Audio' ? (
+        fileUrl ? (
+          <div className='player-control-panel !bg-gray-200'>
+            <div className='content'>
+              <Button
+                className='audio-button unstyled'
+                onClick={() => {
                   $pagePlayersState.setKey(props.id, {
                     ...playerState,
-                    position: val[0] * duration,
+                    isPlaying: !playerState.isPlaying,
                   });
                 }}
-                onValueCommit={onSeek}
-                step={0.0001}
-                value={[playerState.position / duration]}
               >
-                <Slider.Track className='seek-bar-slider-track !bg-gray-400'>
-                  <Slider.Range className='seek-bar-slider-range' />
-                </Slider.Track>
-                <Slider.Thumb className='seek-bar-slider-thumb' />
-              </Slider.Root>
+                {playerState.isPlaying ? (
+                  <PauseFill color='black' />
+                ) : (
+                  <PlayFill color='black' />
+                )}
+              </Button>
+              <div className='position-label'>
+                <span className='timestamp position'>{formattedPosition}</span>
+                <span>&nbsp;/&nbsp;</span>
+                <span className='timestamp duration'>{formattedDuration}</span>
+              </div>
+              <div className='seek-bar'>
+                <Slider.Root
+                  className='seek-bar-slider'
+                  defaultValue={[props.start ? props.start / duration : 0]}
+                  min={props.start ? props.start / duration : 0}
+                  max={0.999999999}
+                  onValueChange={(val) => {
+                    setSeeking(true);
+                    $pagePlayersState.setKey(props.id, {
+                      ...playerState,
+                      position: val[0] * duration,
+                    });
+                  }}
+                  onValueCommit={onSeek}
+                  step={0.0001}
+                  value={[playerState.position / duration]}
+                >
+                  <Slider.Track className='seek-bar-slider-track !bg-gray-400'>
+                    <Slider.Range className='seek-bar-slider-range' />
+                  </Slider.Track>
+                  <Slider.Thumb className='seek-bar-slider-thumb' />
+                </Slider.Root>
+              </div>
+              <Button
+                className='audio-button unstyled'
+                onClick={() => setMuted(!muted)}
+              >
+                {muted ? (
+                  <VolumeMuteFill color='black' />
+                ) : (
+                  <VolumeUpFill color='black' />
+                )}
+              </Button>
             </div>
-            <Button
-              className='audio-button unstyled'
-              onClick={() => setMuted(!muted)}
-            >
-              {muted ? (
-                <VolumeMuteFill color='black' />
-              ) : (
-                <VolumeUpFill color='black' />
-              )}
-            </Button>
           </div>
-        </div>
-      )}
+        ) : (
+          <span className='inline-block italic h-[48px]'>
+            This file is hosted offline.
+          </span>
+        )
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
### In this PR
- Removes the duration indicator from the `AudioFilePicker` component, as it is redundant for online files (also shown in the player) and is a confusing dummy value for offline files;
- Hides the audio player in the case that there is no file URL for a given file, replacing it with brief text indicating that the file is offline. (Open to comments on exactly what that text should read, obviously! And for where the string should live; probably ideally not just hard coded into the component file. In a translation file?)

![image](https://github.com/user-attachments/assets/5ae9a9fd-fd5b-4f62-b67e-c7297028137c)

This addresses https://github.com/AVAnnotate/admin-client/issues/221#issuecomment-2554780048 .
