### PR TITLE
Removing weird extra spaces; other styling tweaks

### DIFF
--- a/src/components/RichText/RichTextElement.astro
+++ b/src/components/RichText/RichTextElement.astro
@@ -35,7 +35,7 @@ const getImageClass = (size: 'thumbnail' | 'medium' | 'large' | 'full') => {
         );
       case 'bulleted-list':
         return (
-          <ul style={style} {...attributes}>
+          <ul class='list-disc list-inside' style={style} {...attributes}>
             <slot />
           </ul>
         );
@@ -53,13 +53,13 @@ const getImageClass = (size: 'thumbnail' | 'medium' | 'large' | 'full') => {
         );
       case 'list-item':
         return (
-          <li style={style} {...attributes}>
+          <li class='indent-4' style={style} {...attributes}>
             <slot />
           </li>
         );
       case 'numbered-list':
         return (
-          <ol style={style} {...attributes}>
+          <ol class='list-decimal list-inside' style={style} {...attributes}>
             <slot />
           </ol>
         );

--- a/src/components/RichText/RichTextElement.astro
+++ b/src/components/RichText/RichTextElement.astro
@@ -80,10 +80,10 @@ const getImageClass = (size: 'thumbnail' | 'medium' | 'large' | 'full') => {
       case 'grid':
         return (
           <div
-            className='slate-grid'
             style={{
               display: 'grid',
               gridTemplateColumns: `${element.layout[0]}fr ${element.layout[1]}fr`,
+              gap: '1rem',
             }}
             {...attributes}
           >

--- a/src/components/RichText/RichTextLeaf.astro
+++ b/src/components/RichText/RichTextLeaf.astro
@@ -11,20 +11,18 @@ import Underline from './Leaves/Underline.astro';
 const { leaf } = Astro.props;
 ---
 
-<Bold leaf={leaf}>
-  <Code leaf={leaf}>
-    <Color leaf={leaf}>
-      <Highlight leaf={leaf}>
-        <Italic leaf={leaf}>
-          <LinkText leaf={leaf}>
-            <Strikethrough leaf={leaf}>
-              <Underline leaf={leaf}>
-                <slot />
-              </Underline>
-            </Strikethrough>
-          </LinkText>
-        </Italic>
-      </Highlight>
-    </Color>
-  </Code>
-</Bold>
+<Bold leaf={leaf}
+  ><Code leaf={leaf}
+    ><Color leaf={leaf}
+      ><Highlight leaf={leaf}
+        ><Italic leaf={leaf}
+          ><LinkText leaf={leaf}
+            ><Strikethrough leaf={leaf}
+              ><Underline leaf={leaf}><slot /></Underline></Strikethrough
+            ></LinkText
+          ></Italic
+        ></Highlight
+      ></Color
+    ></Code
+  ></Bold
+>


### PR DESCRIPTION
### In this PR
- Adjusts the `RichTextLeaf` component so that extraneous spaces are no longer getting appended to formatted text elements.
- Also seems to include a couple of commits that @camdendotlol made yesterday (this branch was based off his `styling-fixes` branch), so he can comment on whether those changes are ready to go (some adjustment to list styling and grid spacing, it seems).

The space issue addresses one of the bullet points of Issue #115 .