### PR TITLE
Added styling for image alignment

### DIFF
--- a/src/components/RichText/RichTextElement.astro
+++ b/src/components/RichText/RichTextElement.astro
@@ -23,6 +23,14 @@ const getImageClass = (size: 'thumbnail' | 'medium' | 'large' | 'full') => {
 {
   (async () => {
     const style = { textAlign: element.align };
+    const imgStyle = {
+      margin:
+        element.align == 'center'
+          ? '0 auto'
+          : element.align == 'right'
+            ? '0 0 0 auto'
+            : '0',
+    };
 
     switch (element.type) {
       case 'line-break':
@@ -66,7 +74,11 @@ const getImageClass = (size: 'thumbnail' | 'medium' | 'large' | 'full') => {
       case 'image':
         return (
           <div {...attributes} style={style}>
-            <img src={element.url} class={getImageClass(element.size)} />
+            <img
+              src={element.url}
+              class={getImageClass(element.size)}
+              style={imgStyle}
+            />
             <slot />
           </div>
         );


### PR DESCRIPTION
### In this PR
Adds some rather clunky CSS to correctly align image elements in the rich text components -- previously only the `text-align` style was being applied, which was not placing images properly. The way I've done it here is by adjusting the image margins based on whether it's left/right/center-aligned, which seems to work fine. Could also (maybe more elegantly?) be done by making the `div` surrounding the `img` have `display: flex` and `justify-content: center` but I wasn't sure about ripple effects from messing with the `display` attribute so did it this way for now.

This addresses one of the bullet points of Issue #115 .