### PR TITLE
Order of annotation sets in tag detail pages

### DIFF
--- a/src/pages/tags/detail/[category]/[tag].astro
+++ b/src/pages/tags/detail/[category]/[tag].astro
@@ -65,7 +65,22 @@ const title = `Annotations for ${capitalizedCategory}: ${capitalizedTag}`;
 
 const annotationSets = await getCollection('annotations');
 const events = await getCollection('events');
-
+annotationSets.sort((a, b) => {
+  const event_a = events.find((ev) => ev.id == a.data.event_id);
+  const event_b = events.find((ev) => ev.id == b.data.event_id);
+  if (event_a && event_b) {
+    return event_a.data.label < event_b.data.label
+      ? -1
+      : event_a.data.label > event_b.data.label
+        ? 1
+        : a.data.set < b.data.set
+          ? -1
+          : a.data.set > b.data.set
+            ? 1
+            : 0;
+  }
+  return 0;
+});
 const categoryData = projectData.data.project.tags.tagGroups.find(
   (tg) =>
     tg.category.replaceAll('_', '').toLocaleLowerCase() ===

--- a/src/pages/tags/detail/[category]/[tag].astro
+++ b/src/pages/tags/detail/[category]/[tag].astro
@@ -65,22 +65,7 @@ const title = `Annotations for ${capitalizedCategory}: ${capitalizedTag}`;
 
 const annotationSets = await getCollection('annotations');
 const events = await getCollection('events');
-annotationSets.sort((a, b) => {
-  const event_a = events.find((ev) => ev.id == a.data.event_id);
-  const event_b = events.find((ev) => ev.id == b.data.event_id);
-  if (event_a && event_b) {
-    return event_a.data.label < event_b.data.label
-      ? -1
-      : event_a.data.label > event_b.data.label
-        ? 1
-        : a.data.set < b.data.set
-          ? -1
-          : a.data.set > b.data.set
-            ? 1
-            : 0;
-  }
-  return 0;
-});
+annotationSets.sort((a, b) => compareAnnotations(a, b, events));
 const categoryData = projectData.data.project.tags.tagGroups.find(
   (tg) =>
     tg.category.replaceAll('_', '').toLocaleLowerCase() ===

--- a/src/pages/tags/detail/[category]/index.astro
+++ b/src/pages/tags/detail/[category]/index.astro
@@ -58,7 +58,22 @@ const title = `${capitalizedCategory} Tags Used in Events`;
 
 const annotationSets = await getCollection('annotations');
 const events = await getCollection('events');
-
+annotationSets.sort((a, b) => {
+  const event_a = events.find((ev) => ev.id == a.data.event_id);
+  const event_b = events.find((ev) => ev.id == b.data.event_id);
+  if (event_a && event_b) {
+    return event_a.data.label < event_b.data.label
+      ? -1
+      : event_a.data.label > event_b.data.label
+        ? 1
+        : a.data.set < b.data.set
+          ? -1
+          : a.data.set > b.data.set
+            ? 1
+            : 0;
+  }
+  return 0;
+});
 const categoryData = projectData.data.project.tags.tagGroups.find(
   (tg) =>
     tg.category.replaceAll('_', '').toLocaleLowerCase() ===

--- a/src/pages/tags/detail/[category]/index.astro
+++ b/src/pages/tags/detail/[category]/index.astro
@@ -12,6 +12,7 @@ import { dynamicConfig } from 'dynamic-astro-config';
 import { ArrowLeft, ArrowCounterclockwise } from 'react-bootstrap-icons';
 import {
   tagColors as colors,
+  compareAnnotations,
   fromTagParam,
   getTagDisplay,
   toTagParam,
@@ -58,22 +59,7 @@ const title = `${capitalizedCategory} Tags Used in Events`;
 
 const annotationSets = await getCollection('annotations');
 const events = await getCollection('events');
-annotationSets.sort((a, b) => {
-  const event_a = events.find((ev) => ev.id == a.data.event_id);
-  const event_b = events.find((ev) => ev.id == b.data.event_id);
-  if (event_a && event_b) {
-    return event_a.data.label < event_b.data.label
-      ? -1
-      : event_a.data.label > event_b.data.label
-        ? 1
-        : a.data.set < b.data.set
-          ? -1
-          : a.data.set > b.data.set
-            ? 1
-            : 0;
-  }
-  return 0;
-});
+annotationSets.sort((a, b) => compareAnnotations(a, b, events));
 const categoryData = projectData.data.project.tags.tagGroups.find(
   (tg) =>
     tg.category.replaceAll('_', '').toLocaleLowerCase() ===

--- a/src/pages/tags/detail/index.astro
+++ b/src/pages/tags/detail/index.astro
@@ -8,7 +8,7 @@ import { getCollection } from 'astro:content';
 import AnnotationSpectrum from '@components/TagUtils/AnnotationSpectrum.astro';
 import TagPill from '@components/TagUtils/TagPill';
 import { CheckIcon } from '@heroicons/react/24/outline';
-import { getTagDisplay, toTagParam } from '@utils/tags';
+import { compareAnnotations, getTagDisplay, toTagParam } from '@utils/tags';
 
 const projectData = await getEntry('project', 'project');
 
@@ -34,22 +34,7 @@ const crumbs = [
 
 const annotationSets = await getCollection('annotations');
 const events = await getCollection('events');
-annotationSets.sort((a, b) => {
-  const event_a = events.find((ev) => ev.id == a.data.event_id);
-  const event_b = events.find((ev) => ev.id == b.data.event_id);
-  if (event_a && event_b) {
-    return event_a.data.label < event_b.data.label
-      ? -1
-      : event_a.data.label > event_b.data.label
-        ? 1
-        : a.data.set < b.data.set
-          ? -1
-          : a.data.set > b.data.set
-            ? 1
-            : 0;
-  }
-  return 0;
-});
+annotationSets.sort((a, b) => compareAnnotations(a, b, events));
 
 // check whether there actually are any annotation files
 if (annotationSets.length === 0) {

--- a/src/pages/tags/detail/index.astro
+++ b/src/pages/tags/detail/index.astro
@@ -33,14 +33,28 @@ const crumbs = [
 ];
 
 const annotationSets = await getCollection('annotations');
+const events = await getCollection('events');
+annotationSets.sort((a, b) => {
+  const event_a = events.find((ev) => ev.id == a.data.event_id);
+  const event_b = events.find((ev) => ev.id == b.data.event_id);
+  if (event_a && event_b) {
+    return event_a.data.label < event_b.data.label
+      ? -1
+      : event_a.data.label > event_b.data.label
+        ? 1
+        : a.data.set < b.data.set
+          ? -1
+          : a.data.set > b.data.set
+            ? 1
+            : 0;
+  }
+  return 0;
+});
 
 // check whether there actually are any annotation files
 if (annotationSets.length === 0) {
   return Astro.redirect(`/${baseUrl}`);
 }
-
-const events = await getCollection('events');
-
 const formattedCategoryNames = projectData.data.project.tags.tagGroups.map(
   (cat) => getTagDisplay(cat.category)
 );

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -47,3 +47,21 @@ export const toTagParam = (str: string) => {
 
   return str.replaceAll(' ', '_').toLocaleLowerCase();
 };
+
+//sorting function for annotation sets, for use on tag detail pages
+export const compareAnnotations = (a: any, b: any, events: any) => {
+  const event_a = events.find((ev: any) => ev.id == a.data.event_id);
+  const event_b = events.find((ev: any) => ev.id == b.data.event_id);
+  if (event_a && event_b) {
+    return event_a.data.label < event_b.data.label
+      ? -1
+      : event_a.data.label > event_b.data.label
+        ? 1
+        : a.data.set < b.data.set
+          ? -1
+          : a.data.set > b.data.set
+            ? 1
+            : 0;
+  }
+  return 0;
+}

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -53,13 +53,13 @@ export const compareAnnotations = (a: any, b: any, events: any) => {
   const event_a = events.find((ev: any) => ev.id == a.data.event_id);
   const event_b = events.find((ev: any) => ev.id == b.data.event_id);
   if (event_a && event_b) {
-    return event_a.data.label < event_b.data.label
+    return event_a.data.label.toLowerCase() < event_b.data.label.toLowerCase()
       ? -1
-      : event_a.data.label > event_b.data.label
+      : event_a.data.label.toLowerCase() > event_b.data.label.toLowerCase()
         ? 1
-        : a.data.set < b.data.set
+        : a.data.set.toLowerCase() < b.data.set.toLowerCase()
           ? -1
-          : a.data.set > b.data.set
+          : a.data.set.toLowerCase() > b.data.set.toLowerCase()
             ? 1
             : 0;
   }


### PR DESCRIPTION
### In this PR
Quick and dirty fix for the fact that annotations sets are being displayed in an apparently nonsensical order on the various tag detail pages. This fix should have them ordered alphabetically by event label and then alphabetically by set name.