### PR TITLE
Added horizontal separator and paragraph padding

### DIFF
--- a/src/components/EventViewer/AudioEvent.astro
+++ b/src/components/EventViewer/AudioEvent.astro
@@ -35,7 +35,7 @@ const {
 <div>
   <div class={`sticky top-0 z-10 ${!isEmbed ? 'shadow' : ''}`}>
     <div class='flex flex-col gap-6 bg-gray-100 py-6 [&_p]:mb-0!'>
-      <ConditionalContainer condition={!isEmbed}>
+      <ConditionalContainer condition={!isEmbed} className='textContent'>
         <div class='flex justify-between'>
           {
             includes.includes('label') && (

--- a/src/components/EventViewer/VideoEvent.astro
+++ b/src/components/EventViewer/VideoEvent.astro
@@ -61,7 +61,7 @@ const captionSets = await getCaptionSets(event, file, annotationSets);
               vttURLs={captionSets}
               initialFile={file}
             />
-            <>
+            <div class='textContent'>
               {!start &&
               !end &&
               Object.keys(event.data.audiovisual_files).length > 1 ? (
@@ -79,7 +79,7 @@ const captionSets = await getCaptionSets(event, file, annotationSets);
                     )}
                 </>
               )}
-            </>
+            </div>
           </div>
         )}
         {includes.includes('annotations') && (

--- a/src/components/RichText/RichTextElement.astro
+++ b/src/components/RichText/RichTextElement.astro
@@ -139,7 +139,7 @@ const getImageClass = (size: 'thumbnail' | 'medium' | 'large' | 'full') => {
         );
       default:
         return (
-          <p class='py-3 leading-6' style={style} {...attributes}>
+          <p class='min-h-6 leading-6' style={style} {...attributes}>
             <slot />
           </p>
         );

--- a/src/components/RichText/RichTextElement.astro
+++ b/src/components/RichText/RichTextElement.astro
@@ -59,6 +59,8 @@ const getImageClass = (size: 'thumbnail' | 'medium' | 'large' | 'full') => {
             <slot />
           </h2>
         );
+      case 'horizontal-separator':
+        return <div class='w-full my-3 h-[1px] bg-black' />;
       case 'list-item':
         return (
           <li class='indent-4' style={style} {...attributes}>
@@ -137,7 +139,7 @@ const getImageClass = (size: 'thumbnail' | 'medium' | 'large' | 'full') => {
         );
       default:
         return (
-          <p class='min-h-6 leading-6' style={style} {...attributes}>
+          <p class='py-3 leading-6' style={style} {...attributes}>
             <slot />
           </p>
         );

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,7 +21,7 @@ if (homePageQuery.length > 0) {
 ---
 
 <Layout title={project.title}>
-  <Container className='py-12 flex flex-col gap-6'>
+  <Container className='py-12 flex flex-col gap-6 textContent'>
     {homePage
       ? (
         <RichText nodes={homePage.data.content} />

--- a/src/pages/pages/[pageSlug].astro
+++ b/src/pages/pages/[pageSlug].astro
@@ -33,7 +33,7 @@ const page = await getPage(pageSlug);
 
 <Layout title={page.data.title}>
   <Container className='py-16'>
-    <div>
+    <div class='textContent'>
       <h1>{page.data.title}</h1>
       <RichText nodes={page.data.content} />
     </div>

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -12,3 +12,10 @@
         @apply font-semibold;
     }
 }
+
+@layer components {
+    .textContent p {
+        @apply min-h-0;
+        @apply py-3;
+    }
+}


### PR DESCRIPTION
### In this PR
Adds a case for the type `horizontal-spacer` to the rich text renderer, and adds a bit of vertical padding around basic paragraph elements to better match the visual layout of the RTE in the admin client.

### Notes
This is related to Issue #127, which refers to specifically this page: https://tanyaclement.github.io/znh-1939/pages/introduction/ . Is the paragraph spacing something that we in fact want in general on all projects, or just something we want for that page? (Personally I like having the spacing between paragraphs, but just want to make sure since this is a general fix not just related to that project.) 