### PR TITLE
Adding citation to bottom of events

### DIFF
--- a/src/components/EventViewer/AudioEvent.astro
+++ b/src/components/EventViewer/AudioEvent.astro
@@ -112,4 +112,7 @@ const {
       initialFile={file}
     />
   </ConditionalContainer>
+  <ConditionalContainer condition={event.data.citation}>
+    <p class='py-3 mb-3'>{event.data.citation}</p>
+  </ConditionalContainer>
 </div>

--- a/src/components/EventViewer/VideoEvent.astro
+++ b/src/components/EventViewer/VideoEvent.astro
@@ -101,3 +101,6 @@ const captionSets = await getCaptionSets(event, file, annotationSets);
     )
   }
 </ConditionalContainer>
+<ConditionalContainer condition={event.data.citation}>
+  <p class='py-3 mb-3'>{event.data.citation}</p>
+</ConditionalContainer>


### PR DESCRIPTION
### In this PR
As per https://github.com/AVAnnotate/admin-client/issues/223, adds the event citation, if defined, at the bottom of the auto-generated event pages.

### Notes and questions
This is a simple implementation without going deep into making it configurable whether or not to display the citation for a given event; should that be something we let users specific in the admin CMS, or is it all right to assume that if they fill in the citation field it should be displayed? Also, should anything more be done with formatting or labeling it? (It seems that field is currently a plaintext string, not rich text; should it be italicized here or anything?)

![image](https://github.com/user-attachments/assets/9ee424c9-4f4c-4eba-a1d8-bccd54a7327f)
