### PR TITLE
Remove home page link from autogenerated ToC

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -22,15 +22,6 @@ if (!homePage) {
 
 <div class='py-4 flex flex-col gap-2'>
   {
-    ![baseUrl.replaceAll('/', ''), ''].includes(
-      Astro.url.pathname.replaceAll('/', '')
-    ) && (
-      <a class='underline' href={`/${baseUrl || ''}`}>
-        {homePage.data.title}
-      </a>
-    )
-  }
-  {
     pages
       .filter((page) => page.id !== homePage.id)
       .map((page) => (

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -11,11 +11,6 @@ const baseUrl = import.meta.env.PROD
     : undefined
   : dynamicConfig.base;
 
-console.log('baseUrl: ', baseUrl);
-console.log('prod', import.meta.env.PROD);
-console.log('slug', projectData.data.project.slug);
-console.log('astro', Astro.url.pathname);
-
 const pages = await getPages();
 
 const homePage = pages.find((p) => p.data.autogenerate.type === 'home');
@@ -27,7 +22,7 @@ if (!homePage) {
 
 <div class='py-4 flex flex-col gap-2'>
   {
-    ![`index.html${baseUrl}`, `${baseUrl}`, ''].includes(
+    ![baseUrl.replaceAll('/', ''), ''].includes(
       Astro.url.pathname.replaceAll('/', '')
     ) && (
       <a class='underline' href={`/${baseUrl || ''}`}>

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -18,13 +18,13 @@ const homePage = pages.find((p) => p.data.autogenerate.type === 'home');
 if (!homePage) {
   throw new Error('No homepage found?!?');
 }
-
-console.log(`/${baseUrl}/`, Astro.url.pathname);
 ---
 
 <div class='py-4 flex flex-col gap-2'>
   {
-    ![`/${baseUrl}/`, '/'].includes(Astro.url.pathname) && (
+    ![`index.html${baseUrl}`, `${baseUrl}`, ''].includes(
+      Astro.url.pathname.replaceAll('/', '')
+    ) && (
       <a class='underline' href={`/${baseUrl || ''}`}>
         {homePage.data.title}
       </a>

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -11,6 +11,11 @@ const baseUrl = import.meta.env.PROD
     : undefined
   : dynamicConfig.base;
 
+console.log('baseUrl: ', baseUrl);
+console.log('prod', import.meta.env.PROD);
+console.log('slug', projectData.data.project.slug);
+console.log('astro', Astro.url.pathname);
+
 const pages = await getPages();
 
 const homePage = pages.find((p) => p.data.autogenerate.type === 'home');


### PR DESCRIPTION
### In this PR
In some cases the link to the project home page is not being successfully hidden from the autogenerated table of contents; the issue seems to be that the `Astro.url.pathname` value does not always include the trailing `/`, which was causing the build process to fail to identify the home page as the home page. Just stripping the `/` characters before comparing is a bit of a brute force fix but seems like it should be reliable.