### PR TITLE
Small fix to scrolling

### DIFF
--- a/src/components/EventViewer/AnnotationUI/Annotations/Annotation.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/Annotation.astro
@@ -20,7 +20,7 @@ const tagGroups = projectData.data.project.tags.tagGroups;
 ---
 
 <div
-  class={`annotationNode flex flex-row justify-between gap-4 p-4 my-4 rounded-md bg-white ${ann.file === initialFile ? '' : 'hidden'}`}
+  class={`annotationNode flex flex-row justify-between gap-4 p-4 my-4 scroll-my-20 rounded-md bg-white ${ann.file === initialFile ? '' : 'hidden'}`}
   data-start={ann.start_time}
   data-end={ann.end_time}
   data-file={ann.file}


### PR DESCRIPTION
# Summary

- Addresses https://github.com/AVAnnotate/admin-client/issues/259]

This problem was actually fixed by an earlier[PR](https://github.com/AVAnnotate/project-client/pull/142). The problem was caused by multiple clips on the same page (in this case multiple sets). This PR just tries to ensure that the scrolled-to annotation appears above the footer. 