### PR TITLE
Fix `isPlaying` incorrectly syncing between AV files

### DIFF
--- a/src/components/EventViewer/AnnotationUI/Annotations/Annotation.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/Annotation.astro
@@ -55,6 +55,7 @@ ann.tags.forEach((tag, idx) => {
       data-start={ann.start_time}
       data-end={ann.end_time}
       data-player-id={playerId}
+      data-file={ann.file}
     >
       <PlayCircleIcon className='h-6 w-6' />
     </button>

--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -113,11 +113,13 @@ if (initialTag) {
       }
       thisNode.addEventListener('click', () => {
         const playerId = thisNode.dataset.playerId || 'null';
+        const fileId = thisNode.dataset.file;
+
         $pagePlayersState.setKey(playerId, {
           ...($pagePlayersState.get()[playerId] || defaultState),
           position: Number(thisNode.dataset.start),
           seekTo: Number(thisNode.dataset.start),
-          isPlaying: true,
+          isPlaying: fileId,
         });
       });
     }

--- a/src/components/EventViewer/AudioFile.astro
+++ b/src/components/EventViewer/AudioFile.astro
@@ -56,6 +56,7 @@ const title =
                 end={end}
                 url={fileObj.file_url}
                 type='Audio'
+                fileUuid={file}
               />
             </ConditionalContainer>
           )

--- a/src/components/EventViewer/VideoEventCompare.astro
+++ b/src/components/EventViewer/VideoEventCompare.astro
@@ -67,6 +67,7 @@ const captionSets = await getCaptionSets(event, defaultFile, annotationSets);
           vttURLs={captionSets}
           type='Video'
           url={event.data.audiovisual_files[defaultFile].file_url}
+          fileUuid={defaultFile}
         />
       </>
     )

--- a/src/components/EventViewer/VideoFile.astro
+++ b/src/components/EventViewer/VideoFile.astro
@@ -68,6 +68,7 @@ const title =
                     vttURLs={captionSets}
                     url={fileObj.file_url}
                     type='Video'
+                    fileUuid={file}
                   />
                   <div class='textContent'>
                     {!start && !end && (

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -26,6 +26,7 @@ interface Props {
   vttURLs?: { url: string; label: string }[];
   url?: string | null;
   type: string;
+  fileUuid: string;
 }
 
 const getSegments = (playerState: AnnotationState): [number, number][] => {
@@ -171,7 +172,7 @@ const Player: React.FC<Props> = (props) => {
       if (data.playedSeconds >= duration) {
         $pagePlayersState.setKey(props.id, {
           ...playerState,
-          isPlaying: false,
+          isPlaying: undefined,
           position: data.playedSeconds,
         });
       } else if (
@@ -183,7 +184,7 @@ const Player: React.FC<Props> = (props) => {
 
         $pagePlayersState.setKey(props.id, {
           ...playerState,
-          isPlaying: false,
+          isPlaying: undefined,
         });
 
         // if there's no next segment, leave the player paused (i.e. we've reached the end)
@@ -194,7 +195,7 @@ const Player: React.FC<Props> = (props) => {
               ...playerState,
               seekTo: nextSegment[0],
               position: nextSegment[0],
-              isPlaying: true,
+              isPlaying: props.fileUuid,
             });
           }, 500);
         }
@@ -211,7 +212,7 @@ const Player: React.FC<Props> = (props) => {
     <div className='player'>
       <ReactPlayer
         controls={props.type === 'Video'}
-        playing={playerState.isPlaying}
+        playing={playerState.isPlaying === props.fileUuid}
         muted={muted}
         config={tracksConfig}
         onDuration={(dur) => {
@@ -251,11 +252,13 @@ const Player: React.FC<Props> = (props) => {
                 onClick={() => {
                   $pagePlayersState.setKey(props.id, {
                     ...playerState,
-                    isPlaying: !playerState.isPlaying,
+                    isPlaying: playerState.isPlaying
+                      ? undefined
+                      : props.fileUuid,
                   });
                 }}
               >
-                {playerState.isPlaying ? (
+                {playerState.isPlaying === props.fileUuid ? (
                   <PauseFill color='black' />
                 ) : (
                   <PlayFill color='black' />

--- a/src/pages/tags/detail/[category]/[tag].astro
+++ b/src/pages/tags/detail/[category]/[tag].astro
@@ -175,6 +175,7 @@ for (const set of annotationSets) {
                       fileObj.file_type || sd.event.data.item_type || 'Audio'
                     }
                     client:load
+                    fileUuid={sd.set.data.source_id}
                   />
                   <Annotations
                     playerId={sd.spectrumId}

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,7 +6,7 @@ export interface AnnotationState {
   id: string;
   position: number;
   seekTo?: number;
-  isPlaying: boolean;
+  isPlaying?: string;
   autoScroll: boolean;
   showTags: boolean;
   currentAnnotation?: number;

--- a/src/utils/player.ts
+++ b/src/utils/player.ts
@@ -28,7 +28,6 @@ export const defaultState = {
   avFileUuid: '',
   currentAnnotation: 0,
   id: '',
-  isPlaying: false,
   filteredAnnotations: [],
   position: 0,
   searchQuery: '',


### PR DESCRIPTION
# Summary

This PR addresses #177, which was a more complicated bug than I expected.

The root issue is that every AV player within an `EventViewer` instance shares the same `playerId` value, while the nanostore assumes that a `playerId` refers to only one file (e.g. with values like `isPlaying` and `position`). When the user clicked the play button, the nanostore for the `playerId` was set to `isPlaying`, which applied to both AV files within that event.

Ideally we'd refactor `isPlaying` and similar state to be per-file rather than per-event, but that would be a decent amount of work so I made the fix as narrow as possible since we're in overage.

* changes `isPlaying` from a boolean to an optional string value (the UUID of the file currently playing)
* updates all instances of `isPlaying` throughout the application to use string comparisons to determine whether a given file is playing, and to set `isPlaying` to `undefined` when paused