### PR TITLE
Filter annotations for clips

### DIFF
--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -220,7 +220,34 @@ if (initialTag) {
     for (const node of annotationNodes) {
       const uuid = node.getAttribute('data-uuid');
 
-      if (uuid && playerState.filteredAnnotations.includes(uuid)) {
+      let status = 'show';
+
+      if (!uuid || !playerState.filteredAnnotations.includes(uuid)) {
+        status = 'hide';
+      }
+
+      if (playerState.clip) {
+        const annStart = node.getAttribute('data-start');
+        const annEnd = node.getAttribute('data-end');
+
+        if (annStart && annEnd) {
+          const annStartInt = parseInt(annStart);
+          const annEndInt = parseInt(annEnd);
+
+          const startFits =
+            annStartInt > playerState.clip.start &&
+            annStartInt < playerState.clip.end;
+          const endFits =
+            annEndInt > playerState.clip.start &&
+            annEndInt < playerState.clip.end;
+
+          if (!startFits || !endFits) {
+            status = 'hide';
+          }
+        }
+      }
+
+      if (status === 'show') {
         showNode(node);
       } else {
         hideNode(node);

--- a/src/components/EventViewer/AudioFile.astro
+++ b/src/components/EventViewer/AudioFile.astro
@@ -6,7 +6,6 @@ import Annotations from './AnnotationUI/Annotations/index.astro';
 import AnnotationHeader from './AnnotationUI/AnnotationHeader.astro';
 import ConditionalContainer from './ConditionalContainer.astro';
 import EventHeader from './EventHeader.astro';
-import { discriminatedUnion } from 'astro:schema';
 
 interface Props extends SlateEventNodeProps {
   annotationSets: CollectionEntry<'annotations'>[];

--- a/src/components/EventViewer/PlayerStateNanostorePopulator.tsx
+++ b/src/components/EventViewer/PlayerStateNanostorePopulator.tsx
@@ -9,6 +9,10 @@ interface Props {
   playerId: string;
   isEmbed?: boolean;
   initialFile: string;
+  clip?: {
+    start: number;
+    end: number;
+  };
 }
 
 const PlayerStateNanostorePopulator: React.FC<Props> = (props) => {
@@ -19,6 +23,7 @@ const PlayerStateNanostorePopulator: React.FC<Props> = (props) => {
       ...state,
       isEmbed: props.isEmbed,
       avFileUuid: props.initialFile,
+      clip: props.clip,
     });
   }, [props.playerId, props.isEmbed]);
 

--- a/src/components/EventViewer/index.astro
+++ b/src/components/EventViewer/index.astro
@@ -18,7 +18,7 @@ export interface Props extends Omit<SlateEventNodeProps, 'uuid' | 'includes'> {
   isComparison?: boolean;
 }
 
-const { isEmbed, file, uuid, playerId } = Astro.props;
+const { isEmbed, file, uuid, playerId, start, end } = Astro.props;
 
 const event = await getEntry('events', uuid);
 
@@ -55,6 +55,12 @@ const childProps = {
     playerId={playerId}
     isEmbed={isEmbed}
     initialFile={defaultFile}
+    clip={start && end
+      ? {
+          start,
+          end,
+        }
+      : undefined}
     client:only='react'
   />
   {


### PR DESCRIPTION
# Summary

This PR adds logic to the `Annotation` component that hides annotations if they don't fall within the clip range (if a clip range exists).

This bug was a little strange because it seems like the filter functionality didn't exist at all prior to this PR, even though it seems like someone would have noticed it a lot sooner if that were the case. The annotations have `data-start` and `data-end` HTML attributes but nothing was reading them. We should definitely have Steve test this change because there's a high chance of weirdness here.