### PR TITLE
Fix autoscroll not working

### DIFF
--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -94,6 +94,7 @@ if (initialTag) {
     const thisNode = annotationPlayNodes[i] as HTMLElement;
 
     if (thisNode.dataset.start && thisNode.dataset.playerId) {
+      const parent = thisNode.closest('.annotationNode') as HTMLElement;
       annotationStarts.push({
         start: Math.floor(Number(thisNode.dataset.start)),
         end:
@@ -102,6 +103,7 @@ if (initialTag) {
             ? Math.floor(Number(thisNode.dataset.end))
             : undefined,
         playerId: thisNode.dataset.playerId,
+        uuid: parent.dataset.uuid!,
       });
 
       $pagePlayersState.setKey(thisNode.dataset.playerId, {
@@ -143,10 +145,6 @@ if (initialTag) {
     const annotationNodes =
       eventContainerEl.querySelectorAll(`.annotationNode`);
 
-    const annotationNodesForScrolling = eventContainerEl.querySelectorAll(
-      `.annotationNode:not(.hidden)`
-    );
-
     const annotationTagNodes =
       eventContainerEl.querySelectorAll(`.annotationTags`);
 
@@ -154,7 +152,7 @@ if (initialTag) {
       (s) => s.playerId === changed
     );
 
-    const current = startTimes?.findIndex((time, idx) => {
+    const current = startTimes?.find((time, idx) => {
       if (typeof time.end === 'number') {
         return (
           time.start <= playerState.position && time.end > playerState.position
@@ -166,8 +164,10 @@ if (initialTag) {
         : time.start <= playerState.position;
     });
 
-    if (typeof current === 'number' && current >= 0) {
-      const activeNode = annotationNodesForScrolling[current] as HTMLElement;
+    if (current) {
+      const activeNode = eventContainerEl.querySelector(
+        `.annotationNode[data-uuid="${current.uuid}"]`
+      ) as HTMLElement | null;
 
       if (activeNode) {
         if (playerState.autoScroll) {
@@ -195,12 +195,13 @@ if (initialTag) {
             activeNode.scrollIntoView({ behavior: 'smooth', block: 'end' });
           }
         }
+
         activeNode.classList.add(activeBackground);
       }
 
-      for (let i = 0; i < annotationNodes.length; i++) {
-        if (i !== current) {
-          annotationNodes[i].classList.remove(activeBackground);
+      for (const a of annotationNodes) {
+        if ((a as HTMLElement).dataset.uuid !== current.uuid) {
+          a.classList.remove(activeBackground);
         }
       }
     }

--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -88,29 +88,25 @@ if (initialTag) {
 
   const annotationPlayNodes = document.querySelectorAll(`.playAnnotation`);
 
+  const annotationStarts = [];
+
   for (let i = 0; i < annotationPlayNodes.length; i++) {
     const thisNode = annotationPlayNodes[i] as HTMLElement;
 
     if (thisNode.dataset.start && thisNode.dataset.playerId) {
-      const annotationStartsNew =
-        $pagePlayersState.get()[thisNode.dataset.playerId]?.annotationStarts;
-
-      if (annotationStartsNew) {
-        annotationStartsNew.push({
-          start: Math.floor(Number(thisNode.dataset.start)),
-          end:
-            Math.floor(Number(thisNode.dataset.end)) >
-            Math.floor(Number(thisNode.dataset.start))
-              ? Math.floor(Number(thisNode.dataset.end))
-              : undefined,
-          playerId: thisNode.dataset.playerId,
-        });
-        $pagePlayersState.setKey(thisNode.dataset.playerId, {
-          ...($pagePlayersState.get()[thisNode.dataset.playerId] ||
-            defaultState),
-          annotationStarts: annotationStartsNew,
-        });
-      }
+      annotationStarts.push({
+        start: Math.floor(Number(thisNode.dataset.start)),
+        end:
+          Math.floor(Number(thisNode.dataset.end)) >
+          Math.floor(Number(thisNode.dataset.start))
+            ? Math.floor(Number(thisNode.dataset.end))
+            : undefined,
+        playerId: thisNode.dataset.playerId,
+      });
+      $pagePlayersState.setKey(thisNode.dataset.playerId, {
+        ...($pagePlayersState.get()[thisNode.dataset.playerId] || defaultState),
+        annotationStarts,
+      });
       thisNode.addEventListener('click', () => {
         const playerId = thisNode.dataset.playerId || 'null';
         const fileId = thisNode.dataset.file;

--- a/src/components/EventViewer/AnnotationUI/Annotations/index.astro
+++ b/src/components/EventViewer/AnnotationUI/Annotations/index.astro
@@ -103,10 +103,12 @@ if (initialTag) {
             : undefined,
         playerId: thisNode.dataset.playerId,
       });
+
       $pagePlayersState.setKey(thisNode.dataset.playerId, {
         ...($pagePlayersState.get()[thisNode.dataset.playerId] || defaultState),
         annotationStarts,
       });
+
       thisNode.addEventListener('click', () => {
         const playerId = thisNode.dataset.playerId || 'null';
         const fileId = thisNode.dataset.file;
@@ -141,6 +143,10 @@ if (initialTag) {
     const annotationNodes =
       eventContainerEl.querySelectorAll(`.annotationNode`);
 
+    const annotationNodesForScrolling = eventContainerEl.querySelectorAll(
+      `.annotationNode:not(.hidden)`
+    );
+
     const annotationTagNodes =
       eventContainerEl.querySelectorAll(`.annotationTags`);
 
@@ -161,7 +167,7 @@ if (initialTag) {
     });
 
     if (typeof current === 'number' && current >= 0) {
-      const activeNode = annotationNodes[current] as HTMLElement;
+      const activeNode = annotationNodesForScrolling[current] as HTMLElement;
 
       if (activeNode) {
         if (playerState.autoScroll) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -12,7 +12,12 @@ export interface AnnotationState {
   currentAnnotation?: number;
   searchQuery?: string;
   tags: Tag[];
-  annotationStarts?: { start: number; end?: number; playerId: string }[];
+  annotationStarts?: {
+    start: number;
+    end?: number;
+    playerId: string;
+    uuid: string;
+  }[];
   sets: string[];
   avFileUuid: string;
   annotations: DisplayedAnnotation[];
@@ -114,6 +119,7 @@ const getFilteredAnnotations = (
     start: ann.start_time,
     end: ann.end_time || undefined,
     playerId: playerId,
+    uuid: ann.uuid,
   }));
 
   return {


### PR DESCRIPTION
# Summary

Autoscroll seems to have been broken because a client-side script was trying to fill the `annotationStarts` array in the player state based on the already-existing value for `annotationStarts`. Since this value wasn't populated anywhere else, the annotations component wasn't aware of the annotation list when determining which ones to scroll to.