### PR TITLE
Adjusted sidebar height to account for footer

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -75,7 +75,7 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
         />
       )}
       <Transition show={show}>
-        <div className='shadow absolute top-0 left-0 h-dvh w-80 bg-white w-10 transition duration-200 ease-in-out data-[closed]:-translate-x-full text-black text-sm overflow-y-auto'>
+        <div className='shadow absolute top-0 left-0 h-[calc(100dvh_-_78px)] w-80 bg-white transition duration-200 ease-in-out data-[closed]:-translate-x-full text-black text-sm overflow-y-auto'>
           <div className='flex w-full h-24 justify-end px-8'>
             <button type='button' onClick={() => setShow(false)}>
               <XMarkIcon className='w-8 h-8' />


### PR DESCRIPTION
### In this PR
Adjusted the sidebar height to account for the fixed height of the footer so that content doesn't get hidden behind the footer. 
<img width="1224" height="1135" alt="image" src="https://github.com/user-attachments/assets/87ccd023-9711-4d76-bf94-97aac74d264e" />
