### PR TITLE
Homogenizing link styling in rich text

### DIFF
--- a/src/components/RichText/Leaves/Link.astro
+++ b/src/components/RichText/Leaves/Link.astro
@@ -1,8 +1,5 @@
 ---
 const { leaf } = Astro.props;
-const linkStyle = {
-  color: '#0969c3',
-};
 ---
 
 {
@@ -11,7 +8,7 @@ const linkStyle = {
       href={leaf.link}
       target='_blank'
       rel='noopener noreferrer'
-      style={linkStyle}
+      class='text-blue-link'
     >
       <slot />
     </a>

--- a/src/components/RichText/RichTextElement.astro
+++ b/src/components/RichText/RichTextElement.astro
@@ -81,9 +81,6 @@ const getTextSize = (textSize: string) => {
             ? '0 0 0 auto'
             : '0',
     };
-    const linkStyle = {
-      color: '#0969c3',
-    };
     const columnStyle = {
       paddingLeft: element.left ? `${element.left}%` : 0,
       paddingRight: element.right ? `${element.right}%` : 0,
@@ -94,7 +91,7 @@ const getTextSize = (textSize: string) => {
     switch (element.type) {
       case 'link':
         return (
-          <a style={linkStyle} href={element.url}>
+          <a class='text-blue-link' href={element.url}>
             <slot />
           </a>
         );

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -17,6 +17,7 @@ export default {
         },
         black: '#0A0A0A',
         'blue-hover': '#D9E6ED',
+        'blue-link': '#0969c3'
       },
       screens: {
         '3xl': '1800px',


### PR DESCRIPTION
### In this PR
Updates the styling in the `Leaves/Link.astro` component to match the styling of `link` nodes in the `RichTextElement.astro` component.

### Notes and questions
It definitely feels like the styling should be pulled into both places from some singular source rather than having the CSS hard coded separately in two places, but I wasn't sure what the right place to put that would be, especially with this slightly fragile system of functional components inside Astro components. Open to suggestions.