### PR TITLE
Fix video player to actually stop at the end of clips

### DIFF
--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -217,7 +217,7 @@ const Player: React.FC<Props> = (props) => {
       ...playerState,
       isPlaying: props.fileUuid,
     });
-  }, [props.id, props.fileUuid]);
+  }, [props.id, props.fileUuid, playerState]);
 
   //Callback function for hitting pause on the default controls
   const onPressPause = useCallback(() => {
@@ -225,7 +225,7 @@ const Player: React.FC<Props> = (props) => {
       ...playerState,
       isPlaying: undefined,
     });
-  }, [props.id]);
+  }, [props.id, playerState]);
 
   return (
     <div className='player'>


### PR DESCRIPTION
### In this PR
Fixes the issue mentioned [here](https://github.com/orgs/AVAnnotate/discussions/71) where the specified end times for video clips in embedded events aren't being respected by the player.

### Notes and Questions
It seems the problem here was that with the default controls enabled the `ReactPlayer` will privilege those controls over the `isPlaying` prop, so while it was correctly seeking to the start time in the `onReady` callback, the check in `onProgress` that's supposed to stop it if it hits the end of the clip by updating the player state in the store and thereby updating the `isPlaying` prop was having no effect. The fix for that without implementing fully custom controls seems to be to pass `onPlay` and `onPause` props to the player that override the default methods in the controls, in which case it will fall back to the `isPlaying` value.

The issue with this is that as best I can tell there is no way to tell the default controls to actually cut the bar off at the given start/end times rather than displaying the full length of the video; this leads to a confusing UX where the user can manually seek to any point in the video but it would only play if they happen to land inside the clip. To try to deal with that I set it to only stop automatically within the half second after the clip's end time -- if you click around to anywhere else in the video it will still play, but if you approach the end of the clip then it will pause you there. But arguably that defeats the purpose of having a clip; we're not accommodating the case where the creator of the page wants only a small segment of the video file to be viewable at all. It seems we would need custom video controls to do that (without creating the confusing UX discussed above), which seems like a can of worms. Open to suggestions though.