### PR TITLE
Make spacing match appearance in `admin-client` editor

### DIFF
--- a/src/components/RichText/RichTextElement.astro
+++ b/src/components/RichText/RichTextElement.astro
@@ -39,13 +39,14 @@ const getTextSize = (textSize: string) => {
         fontSize: '24px',
         fontWeight: 'bold',
         lineHeight: '1.2',
-        minHeight: '26px',
+        minHeight: '36px',
       };
     case 'heading-three':
       return {
         fontSize: '18px',
         fontWeight: 'bold',
         lineHeight: 'auto',
+        minHeight: '27px',
       };
     case 'heading-four':
       return {


### PR DESCRIPTION
### In this PR
Addresses the mismatch between the appearance of line spacing and padding in the RTE in the `admin-client` compared to how it's rendered on the frontend site. (See https://github.com/orgs/AVAnnotate/discussions/57) Here's an example:

In the RTE:
<img width="1797" height="1270" alt="image" src="https://github.com/user-attachments/assets/d8682d4e-800a-454e-9206-1013471b24b9" />

Current:
<img width="1813" height="1051" alt="image" src="https://github.com/user-attachments/assets/c418a35a-9d82-46ad-add6-a55cab0424c4" />

With new changes:
<img width="1819" height="1275" alt="image" src="https://github.com/user-attachments/assets/c56b41ad-254c-4ba7-9bf8-1565cbdc9e1e" />
