### PR TITLE
Adds `av_file_order` to event schema and display

### DIFF
--- a/src/components/EventViewer/index.astro
+++ b/src/components/EventViewer/index.astro
@@ -32,9 +32,13 @@ const annotationSets = annotationData.filter(
   (an) => an.data.event_id === event.id
 );
 
+//use av_file_order for ordering if it exists
+const av_file_ids =
+  event.data?.av_file_order || Object.keys(event.data?.audiovisual_files);
+
 // allow a default file to be configured via props
 // otherwise, use the first file in the list
-const defaultFile = file || Object.keys(event.data.audiovisual_files)[0];
+const defaultFile = file || av_file_ids[0];
 
 const childProps = {
   ...Astro.props,
@@ -64,7 +68,7 @@ const childProps = {
     client:only='react'
   />
   {
-    Object.keys(event.data.audiovisual_files).map((uuid) => {
+    av_file_ids?.map((uuid) => {
       const avFile = event.data.audiovisual_files[uuid];
 
       const type = avFile.file_type || event.data.item_type;

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -56,6 +56,7 @@ const eventCollection = defineCollection({
     updated_at: z.string(),
     updated_by: z.string(),
     rights_statement: z.string().nullish(),
+    av_file_order: z.array(z.string()).nullish(),
   }),
 });
 

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -9,7 +9,7 @@ export const getCaptionSets = async (
   const projectData = await getEntry('project', 'project');
 
   const baseUrl = import.meta.env.PROD
-    ? projectData.data.project.slug
+    ? projectData?.data.project.slug
     : dynamicConfig.base;
 
   let captionSets: { url: string; label: string }[];
@@ -32,7 +32,10 @@ export const getCaptionSets = async (
 };
 
 export const getTabEntries = (event: CollectionEntry<'events'>) => {
-  return Object.keys(event.data.audiovisual_files).map((uuid) => ({
+  const av_file_ids =
+    event.data?.av_file_order || Object.keys(event.data?.audiovisual_files);
+
+  return av_file_ids.map((uuid) => ({
     title: event.data.audiovisual_files[uuid].label,
     uuid,
   }));


### PR DESCRIPTION
### In this PR
Addresses (part of) https://github.com/AVAnnotate/admin-client/issues/418#event-21169230134 by adding the `av_file_order` field to the `event` schema on the project client and modifying the default selected file and the tab order for AV files in an event to respect that order if it's present.