### PR TITLE
Fixing tag filter popover getting hidden behind footer

### DIFF
--- a/src/components/EventViewer/AnnotationUI/TagFilter.tsx
+++ b/src/components/EventViewer/AnnotationUI/TagFilter.tsx
@@ -87,7 +87,7 @@ const TagFilter = (props: TagFilterProps) => {
       </PopoverButton>
       <PopoverPanel
         anchor='bottom end'
-        className='flex flex-col w-[400px] bg-white drop-shadow-lg p-6 rounded-md mt-4 z-40'
+        className='flex flex-col w-[400px] bg-white drop-shadow-lg p-6 rounded-md z-10 [--anchor-padding:100px]'
       >
         <p className='text-md font-semibold mb-4'>Filters</p>
         <div className='flex flex-row justify-between w-full pb-2'>


### PR DESCRIPTION
### In this PR
Addresses Issue #211 by adding `--anchor-padding` to the popover component so that it leaves space at the bottom for the footer.
<img width="1122" height="937" alt="image" src="https://github.com/user-attachments/assets/e07558f4-eefa-4f22-ae91-734ada8d3a74" />