### PR TITLE
Remove `uncategorized` tag pill if no tags

### DIFF
--- a/src/pages/tags/detail/index.astro
+++ b/src/pages/tags/detail/index.astro
@@ -60,10 +60,11 @@ const formattedCategoryNames = projectData.data.project.tags.tagGroups.map(
     <div class='tag-list flex flex-row gap-2'>
       {
         projectData.data.project.tags.tagGroups.map((tg, idx) => {
-          const groupTags = projectData?.data.project.tags.tags.filter(
-            (t) => t.category === tg.category
-          );
-          if (groupTags?.length) {
+          if (
+            projectData?.data.project.tags.tags.some(
+              (t) => t.category === tg.category
+            )
+          ) {
             return (
               <TagPill
                 color={tg.color}


### PR DESCRIPTION
### In this PR
Addresses Issue #210 by checking whether there are any tags in a given category before displaying the pill for that category at the top of the `index/detail` page.